### PR TITLE
Replace DynamicVector in ops

### DIFF
--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -112,7 +112,7 @@ struct Graph:
             )
 
         self.nodes.push_back(
-            Node(op, res, operand_1, operand_2.take(), operand_3.take(), attributes)
+            Node(op, res, operand_1, operand_2, operand_3, attributes)
         )
         self.symbol_count += 1
         return res

--- a/basalt/autograd/symbol.mojo
+++ b/basalt/autograd/symbol.mojo
@@ -25,7 +25,7 @@ struct Symbol(CollectionElement, Stringable):
     fn json(self) -> String:
         return (
             '{"name": "'
-            + str(self.name)[:8]
+            + str(self.name)
             + '", "dtype": "'
             + str(self.dtype)
             + '", "shape": "'

--- a/basalt/nn/tensor.mojo
+++ b/basalt/nn/tensor.mojo
@@ -3,7 +3,6 @@ from testing import assert_true
 
 from tensor import Tensor as _Tensor
 from tensor import TensorShape as _TensorShape
-from collections.vector import InlinedFixedVector
 
 
 alias max_rank = 8
@@ -43,6 +42,11 @@ struct TensorShape(Stringable):
             self._shape[i] = shape[i]
 
     @always_inline("nodebug")
+    fn __init__(inout self, rank: Int, shape: StaticIntTuple[max_rank]):
+        self._rank = rank
+        self._shape = shape
+
+    @always_inline("nodebug")
     fn __getitem__(self, index: Int) -> Int:
         return self._shape[index if index >= 0 else self._rank + index]
 
@@ -62,10 +66,10 @@ struct TensorShape(Stringable):
         return result
 
     @always_inline("nodebug")
-    fn strides(self) -> InlinedFixedVector[Int]:
-        var result = InlinedFixedVector[Int](self.rank())
-        result[self.rank() - 1] = 1
-        for i in range(self.rank() - 2, -1, -1):
+    fn strides(self) -> StaticIntTuple[max_rank]:
+        var result = StaticIntTuple[max_rank](0)
+        result[self._rank - 1] = 1
+        for i in range(self._rank - 2, -1, -1):
             result[i] = result[i + 1] * self._shape[i + 1]
         return result
 
@@ -152,7 +156,7 @@ struct Tensor[dtype: DType](Stringable, Movable, CollectionElement):
         self._data.simd_store[simd_width](index, value)
 
     @always_inline("nodebug")
-    fn strides(self) -> InlinedFixedVector[Int]:
+    fn strides(self) -> StaticIntTuple[max_rank]:
         return self._shape.strides()
 
     @always_inline("nodebug")

--- a/examples/sin_estimate.mojo
+++ b/examples/sin_estimate.mojo
@@ -39,6 +39,12 @@ fn main():
 
     alias graph = create_simple_nn(batch_size, n_inputs, n_outputs)
 
+    # try:
+    #     graph.render("operator")
+    # except e:
+    #     print("Failed to render graph")
+    #     print(e)
+
     var model = nn.Model[graph]()
     var optimizer = nn.optim.Adam[graph](lr=learning_rate)
     optimizer.allocate_rms_and_momentum(model.parameters)


### PR DESCRIPTION
Exploring the possibility of avoiding the call to the general `(un)broadcasting` functions, and specifically focus on tensors of rank 1 or 2 (as in the Linear layer). As shapes are statically known, broadcasting & unbroadcasting could end up in another entrypoint without any overhead.

This would have the possiblity of reducing the overhead on `get_real_index` in `broadcast_shapes` and `accumulate_grad` as seen in the `sin_estimate.mojo` benchmark, which contains multiple Linear layers