### PR TITLE
Fixed library to work with version 24.2 mojo

### DIFF
--- a/basalt/autograd/attributes.mojo
+++ b/basalt/autograd/attributes.mojo
@@ -12,11 +12,11 @@ alias max_attr_value_size = 32
 
 @register_passable("trivial")
 struct AttributeVector(Sized, Stringable, CollectionElement):
-    var _attrs: StaticTuple[max_attrs, Attribute]
+    var _attrs: StaticTuple[Attribute, max_attrs]
     var _size: Int
 
     fn __init__(inout self, *attributes: Attribute):
-        self._attrs = StaticTuple[max_attrs, Attribute]()
+        self._attrs = StaticTuple[Attribute, max_attrs]()
         self._size = len(attributes)
         for i in range(self._size):
             self._attrs[i] = attributes[i]

--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -13,24 +13,24 @@ from basalt import Tensor, TensorShape
 
 @value
 struct Graph:
-    var inputs: DynamicVector[Symbol]
+    var inputs: List[Symbol]
     var params: ParamDict
-    var nodes: DynamicVector[Node]
-    var outputs: DynamicVector[Symbol]
+    var nodes: List[Node]
+    var outputs: List[Symbol]
     var loss_out: Optional[Symbol]
     var symbol_count: UInt32
 
     fn __init__(inout self):
-        self.inputs = DynamicVector[Symbol]()
+        self.inputs = List[Symbol]()
         self.params = ParamDict()
-        self.nodes = DynamicVector[Node]()
-        self.outputs = DynamicVector[Symbol]()
+        self.nodes = List[Node]()
+        self.outputs = List[Symbol]()
         self.loss_out = None
         self.symbol_count = 0
 
     fn input(inout self, shape: TensorShape) -> Symbol:
         var inp = Symbol(self.symbol_count, dtype, shape, False)
-        self.inputs.push_back(inp)
+        self.inputs.append(inp)
         self.symbol_count += 1
         return inp
 
@@ -58,7 +58,7 @@ struct Graph:
         return scalar_id
 
     fn constant(
-        inout self, shape: TensorShape, data: DynamicVector[SIMD[dtype, 1]]
+        inout self, shape: TensorShape, data: List[SIMD[dtype, 1]]
     ) -> Symbol:
         var cst = Param(data)
         var constant_id = Symbol(self.symbol_count, dtype, shape, trainable=False)
@@ -67,7 +67,7 @@ struct Graph:
         return constant_id
 
     fn out(inout self, symbol: Symbol):
-        self.outputs.push_back(symbol)
+        self.outputs.append(symbol)
 
     fn loss(inout self, symbol: Symbol):
         self.loss_out = symbol
@@ -111,7 +111,7 @@ struct Graph:
                 self.result_trainable(operand_1),
             )
 
-        self.nodes.push_back(
+        self.nodes.append(
             Node(op, res, operand_1, operand_2, operand_3, attributes)
         )
         self.symbol_count += 1
@@ -121,7 +121,7 @@ struct Graph:
         inout self,
         op: OP,
         operand_1: Symbol,
-        operand_2: FloatLiteral,
+        operand_2: Float64,
         attributes: AttributeVector = AttributeVector(),
     ) -> Symbol:
         var operand_2_symbol = self.scalar(operand_2)
@@ -134,7 +134,7 @@ struct Graph:
             self.result_trainable(operand_1),
         )
 
-        self.nodes.push_back(
+        self.nodes.append(
             Node(op, res, operand_1, operand_2_symbol, attributes=attributes)
         )
         self.symbol_count += 1
@@ -143,7 +143,7 @@ struct Graph:
     fn op(
         inout self,
         op: OP,
-        operand_1: FloatLiteral,
+        operand_1: Float64,
         operand_2: Symbol,
         attributes: AttributeVector = AttributeVector(),
     ) -> Symbol:
@@ -157,7 +157,7 @@ struct Graph:
             self.result_trainable(operand_2),
         )
 
-        self.nodes.push_back(
+        self.nodes.append(
             Node(op, res, operand_1_symbol, operand_2, attributes=attributes)
         )
         self.symbol_count += 1

--- a/basalt/autograd/params.mojo
+++ b/basalt/autograd/params.mojo
@@ -8,20 +8,20 @@ from .attributes import Attribute
 
 @value
 struct Param(CollectionElement, Stringable):
-    var data: Optional[DynamicVector[SIMD[dtype, 1]]]
+    var data: Optional[List[SIMD[dtype, 1]]]
     var initializer: Optional[Attribute]
 
     fn __init__(inout self):
         self.data = None
         self.initializer = None
 
-    fn __init__(inout self, data: DynamicVector[SIMD[dtype, 1]]):
+    fn __init__(inout self, data: List[SIMD[dtype, 1]]):
         self.data = data
         self.initializer = None
 
     fn __init__(inout self, a: SIMD[dtype, 1]):
-        var data = DynamicVector[SIMD[dtype, 1]]()
-        data.push_back(a)
+        var data = List[SIMD[dtype, 1]]()
+        data.append(a)
         self.data = data
         self.initializer = None
 
@@ -32,9 +32,9 @@ struct Param(CollectionElement, Stringable):
         #   #TODO: "kaiming_uniform", mode, nonlinearity
         #   #TODO: "kaiming_normal", mode, nonlinearity
         self.initializer = Attribute("initializer", initializer)
-        var data = DynamicVector[SIMD[dtype, 1]]()
+        var data = List[SIMD[dtype, 1]]()
         for arg in args:
-            data.push_back(arg)
+            data.append(arg)
         self.data = data
 
     fn __getitem__(self, i: Int) -> Optional[SIMD[dtype, 1]]:
@@ -58,21 +58,21 @@ struct Param(CollectionElement, Stringable):
 
 @value
 struct ParamDict(Sized):
-    var symbols: DynamicVector[Symbol]
-    var values: DynamicVector[Param]
+    var symbols: List[Symbol]
+    var values: List[Param]
 
     fn __init__(inout self):
-        self.symbols = DynamicVector[Symbol]()
-        self.values = DynamicVector[Param]()
+        self.symbols = List[Symbol]()
+        self.values = List[Param]()
 
     fn put(inout self, param_id: Symbol, value: Optional[Param] = None):
-        self.symbols.push_back(param_id)
+        self.symbols.append(param_id)
         if value:
             # Initialized parameter
-            self.values.push_back(value.value())
+            self.values.append(value.value())
         else:
             # Uninitialized parameter
-            self.values.push_back(Param())
+            self.values.append(Param())
 
     fn get_tensor(self, idx: Int) -> Tensor[dtype]:
         # May only be called at runtime

--- a/basalt/nn/initializers.mojo
+++ b/basalt/nn/initializers.mojo
@@ -6,7 +6,7 @@ from basalt.utils.rand_utils import rand_normal, rand_uniform
 
 
 fn initialize_tensor(
-    shape: TensorShape, type: String, data: DynamicVector[SIMD[dtype, 1]]
+    shape: TensorShape, type: String, data: List[SIMD[dtype, 1]]
 ) -> Tensor[dtype]:
     if type == "random_uniform":
         var low = data[0]

--- a/basalt/nn/layers/conv.mojo
+++ b/basalt/nn/layers/conv.mojo
@@ -1,4 +1,4 @@
-# from math import sqrt
+from math import nan
 from basalt import Tensor, TensorShape
 
 from basalt import Graph, Symbol, OP

--- a/basalt/nn/layers/linear.mojo
+++ b/basalt/nn/layers/linear.mojo
@@ -1,4 +1,4 @@
-# from math import sqrt
+from math import nan
 from basalt import Tensor, TensorShape
 
 from basalt import Graph, Symbol, OP

--- a/basalt/nn/model.mojo
+++ b/basalt/nn/model.mojo
@@ -7,7 +7,7 @@ from basalt.utils.tensorutils import fill
 from .initializers import initialize_tensor
 
 
-fn dv_contains(dv: DynamicVector[Symbol], symbol: Symbol) -> Bool:
+fn dv_contains(dv: List[Symbol], symbol: Symbol) -> Bool:
     for i in range(len(dv)):
         if dv[i] == symbol:
             return True
@@ -27,16 +27,16 @@ fn calc_n_inference_nodes(g: Graph) -> Optional[Int]:
     return None
 
 
-fn collect_trainable_parameters(g: Graph) -> DynamicVector[Symbol]:
+fn collect_trainable_parameters(g: Graph) -> List[Symbol]:
     """
     Collect all symbols of trainable parameters.
     """
 
-    var trainable_parameters = DynamicVector[Symbol]()
+    var trainable_parameters = List[Symbol]()
 
     for i in range(len(g.params)):
         if g.params.symbols[i].trainable:
-            trainable_parameters.push_back(g.params.symbols[i])
+            trainable_parameters.append(g.params.symbols[i])
 
     return trainable_parameters ^
 
@@ -98,15 +98,15 @@ struct Model[
         # TODO: known copy (reference?)
         return self.parameters.params[g.loss_out.value()]
 
-    fn inference(inout self, *t_inputs: Tensor[dtype]) -> DynamicVector[Tensor[dtype]]:
+    fn inference(inout self, *t_inputs: Tensor[dtype]) -> List[Tensor[dtype]]:
         # 1. Execute forward pass up to model out
         self.execute[n_inference_nodes.value()](t_inputs)
 
         # 2. Return outputs from allocated output memory
         # TODO: known copies (reference?)
-        var outputs = DynamicVector[Tensor[dtype]]()
+        var outputs = List[Tensor[dtype]]()
         for i in range(len(g.outputs)):
-            outputs.push_back(self.parameters.params[g.outputs[i]])
+            outputs.append(self.parameters.params[g.outputs[i]])
         return outputs ^
 
     fn execute[num_nodes: Int](inout self, t_input: VariadicListMem[Tensor[dtype]]):

--- a/basalt/nn/tensor.mojo
+++ b/basalt/nn/tensor.mojo
@@ -28,7 +28,7 @@ struct TensorShape(Stringable):
             self._shape[i] = shapes[i]
 
     @always_inline("nodebug")
-    fn __init__(inout self, shape: DynamicVector[Int]):
+    fn __init__(inout self, shape: List[Int]):
         self._rank = len(shape)
         self._shape = StaticIntTuple[max_rank]()
         for i in range(min(self._rank, max_rank)):
@@ -75,9 +75,9 @@ struct TensorShape(Stringable):
 
     @always_inline("nodebug")
     fn _std_shape(self) -> _TensorShape:
-        var s = DynamicVector[Int](capacity=self.rank())
+        var s = List[Int](capacity=self.rank())
         for i in range(self.rank()):
-            s.push_back(self[i])
+            s.append(self[i])
         return _TensorShape(s)
 
     @always_inline("nodebug")
@@ -149,11 +149,11 @@ struct Tensor[dtype: DType](Stringable, Movable, CollectionElement):
 
     @always_inline("nodebug")
     fn simd_load[simd_width: Int](self, index: Int) -> SIMD[dtype, simd_width]:
-        return self._data.simd_load[simd_width](index)
+        return self._data.load[width=simd_width](index)
 
     @always_inline("nodebug")
     fn simd_store[simd_width: Int](self, index: Int, value: SIMD[dtype, simd_width]):
-        self._data.simd_store[simd_width](index, value)
+        self._data.store[width=simd_width](index, value)
 
     @always_inline("nodebug")
     fn strides(self) -> StaticIntTuple[max_rank]:

--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -8,16 +8,16 @@ struct bytes[capacity: Int](Stringable, CollectionElement):
     Static sequence of bytes.
     """
 
-    var _vector: StaticTuple[capacity, UInt8]
+    var _vector: StaticTuple[UInt8, capacity]
 
     fn __init__(inout self):
-        var _vector = StaticTuple[capacity, UInt8]()
+        var _vector = StaticTuple[UInt8, capacity]()
         for i in range(capacity):
             _vector[i] = 0
         self._vector = _vector
 
     fn __init__(inout self, s: String):
-        var _vector = StaticTuple[capacity, UInt8]()
+        var _vector = StaticTuple[UInt8, capacity]()
         for i in range(min(len(s), capacity)):
             _vector[i] = ord(s[i])
         self._vector = _vector

--- a/basalt/utils/rand_utils.mojo
+++ b/basalt/utils/rand_utils.mojo
@@ -39,7 +39,7 @@ struct MersenneTwister:
     alias TEMPERING_MASK_B: Int32 = 0x9D2C5680
     alias TEMPERING_MASK_C: Int32 = 0xEFC60000
 
-    var state: StaticTuple[Self.N, Int32]
+    var state: StaticTuple[Int32, Self.N]
     var index: Int
 
     fn __init__(inout self, seed: Int):
@@ -48,7 +48,7 @@ struct MersenneTwister:
         alias D: Int32 = 0xFFFFFFFF
 
         self.index = Self.N
-        self.state = StaticTuple[Self.N, Int32]()
+        self.state = StaticTuple[Int32, Self.N, ]()
         self.state[0] = seed & D
 
         for i in range(1, Self.N):

--- a/basalt/utils/tensorutils.mojo
+++ b/basalt/utils/tensorutils.mojo
@@ -157,7 +157,7 @@ fn dot_transpose_t2[
                     A.simd_load[nelts](A_pos) * B.simd_load[nelts](B_pos)
                 ).reduce_add()
 
-            vectorize[calc_row_A_B, nelts, A_shape[1]]()
+            vectorize[calc_row_A_B, nelts, size=A_shape[1]]()
 
     parallelize[calc_row](A_shape[0], 1)
 
@@ -183,7 +183,7 @@ fn dot_transpose_t1[
                     + A[A_pos] * B.simd_load[nelts](B_pos),
                 )
 
-            vectorize[calc_row_t_new_B, nelts, B_shape[1]]()
+            vectorize[calc_row_t_new_B, nelts, size=B_shape[1]]()
 
     parallelize[calc_row](A_shape[1], 1)
 

--- a/examples/sin_estimate.mojo
+++ b/examples/sin_estimate.mojo
@@ -1,5 +1,6 @@
 from random import rand
 from time.time import now
+import math
 
 import basalt.nn as nn
 from basalt import Tensor, TensorShape

--- a/test/test_backward.mojo
+++ b/test/test_backward.mojo
@@ -109,7 +109,7 @@ fn test_DIV() raises:
 
     var grad2 = DIV.backward[1, ug_shape, t1_shape, t2_shape](ug, t1, t2)
     var expected_grad2 = Tensor[dtype](t2_shape)
-    fill(expected_grad2, -1.0 / (2.0**2))
+    fill[dtype](expected_grad2, -1.0 / (2.0**2))
     assert_tensors_equal(grad2, expected_grad2)
 
 

--- a/test/test_broadcast_shapes.mojo
+++ b/test/test_broadcast_shapes.mojo
@@ -6,9 +6,9 @@ from basalt.utils.tensorutils import broadcast_shapes
 
 
 fn to_tensor_shape(owned shape: PythonObject) raises -> TensorShape:
-    var tensor_shape = DynamicVector[Int]()
+    var tensor_shape = List[Int]()
     for dim in shape:
-        tensor_shape.push_back(dim.to_float64().to_int())
+        tensor_shape.append(dim.to_float64().to_int())
     return TensorShape(tensor_shape)
 
 

--- a/test/test_models_mnist.mojo
+++ b/test/test_models_mnist.mojo
@@ -12,12 +12,12 @@ from test_conv import to_numpy, to_tensor
 
 fn create_CNN(
     batch_size: Int,
-    conv1_weights: DynamicVector[SIMD[dtype, 1]],
-    conv1_bias: DynamicVector[SIMD[dtype, 1]],
-    conv2_weights: DynamicVector[SIMD[dtype, 1]],
-    conv2_bias: DynamicVector[SIMD[dtype, 1]],
-    linear1_weights: DynamicVector[SIMD[dtype, 1]],
-    linear1_bias: DynamicVector[SIMD[dtype, 1]],
+    conv1_weights: List[SIMD[dtype, 1]],
+    conv1_bias: List[SIMD[dtype, 1]],
+    conv2_weights: List[SIMD[dtype, 1]],
+    conv2_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[SIMD[dtype, 1]],
+    linear1_bias: List[SIMD[dtype, 1]],
 ) -> Graph:
     var g = Graph()
     var x = g.input(TensorShape(batch_size, 1, 28, 28))
@@ -89,18 +89,18 @@ fn create_CNN(
 
 fn run_mojo[
     batch_size: Int,
-    conv1_weights: DynamicVector[SIMD[dtype, 1]],
-    conv1_bias: DynamicVector[SIMD[dtype, 1]],
-    conv2_weights: DynamicVector[SIMD[dtype, 1]],
-    conv2_bias: DynamicVector[SIMD[dtype, 1]],
-    linear1_weights: DynamicVector[SIMD[dtype, 1]],
-    linear1_bias: DynamicVector[SIMD[dtype, 1]],
+    conv1_weights: List[SIMD[dtype, 1]],
+    conv1_bias: List[SIMD[dtype, 1]],
+    conv2_weights: List[SIMD[dtype, 1]],
+    conv2_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[SIMD[dtype, 1]],
+    linear1_bias: List[SIMD[dtype, 1]],
 ](
     epochs: Int,
-    learning_rate: FloatLiteral,
+    learning_rate: Float64,
     inputs: Tensor[dtype],
     labels: Tensor[dtype],
-) -> DynamicVector[SIMD[dtype, 1]]:
+) -> List[SIMD[dtype, 1]]:
     alias graph = create_CNN(
         batch_size,
         conv1_weights,
@@ -115,7 +115,7 @@ fn run_mojo[
     var optim = nn.optim.Adam[graph](lr=learning_rate)
     optim.allocate_rms_and_momentum(model.parameters)
 
-    var losses = DynamicVector[SIMD[dtype, 1]]()
+    var losses = List[SIMD[dtype, 1]]()
 
     for i in range(epochs):
         var loss = model.forward(inputs, labels)
@@ -125,14 +125,14 @@ fn run_mojo[
         model.backward()
         optim.step(model.parameters)
 
-        losses.push_back(loss[0])
+        losses.append(loss[0])
 
     return losses
 
 
 fn run_torch(
     epochs: Int,
-    learning_rate: FloatLiteral,
+    learning_rate: Float64,
     inputs: Tensor,
     labels: Tensor,
     owned conv1_weights: Tensor,
@@ -141,8 +141,8 @@ fn run_torch(
     owned conv2_bias: Tensor,
     owned linear1_weights: Tensor,
     owned linear1_bias: Tensor,
-) -> DynamicVector[SIMD[dtype, 1]]:
-    var out: DynamicVector[SIMD[dtype, 1]] = DynamicVector[SIMD[dtype, 1]]()
+) -> List[SIMD[dtype, 1]]:
+    var out: List[SIMD[dtype, 1]] = List[SIMD[dtype, 1]]()
 
     try:
         var torch = Python.import_module("torch")
@@ -188,7 +188,7 @@ fn run_torch(
             _ = loss.backward()
             _ = optimizer.step()
 
-            out.push_back(to_tensor(loss)[0])
+            out.append(to_tensor(loss)[0])
 
         return out
 
@@ -198,17 +198,17 @@ fn run_torch(
         return out
 
 
-fn create_weights(num_elements: Int, zero: Bool) -> DynamicVector[SIMD[dtype, 1]]:
-    var weights = DynamicVector[SIMD[dtype, 1]](capacity=num_elements)
+fn create_weights(num_elements: Int, zero: Bool) -> List[SIMD[dtype, 1]]:
+    var weights = List[SIMD[dtype, 1]](capacity=num_elements)
     for i in range(num_elements):
         if zero:
-            weights.push_back(SIMD[dtype, 1](0.0))
+            weights.append(SIMD[dtype, 1](0.0))
         else:
-            weights.push_back(SIMD[dtype, 1](0.02))
+            weights.append(SIMD[dtype, 1](0.02))
     return weights ^
 
 
-fn dv_to_tensor(dv: DynamicVector[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
+fn dv_to_tensor(dv: List[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
     var t = Tensor[dtype](shape)
     if t.num_elements() != len(dv):
         print("[WARNING] tensor and dv not the shame shape")

--- a/test/test_models_regression.mojo
+++ b/test/test_models_regression.mojo
@@ -14,8 +14,8 @@ from basalt.utils.rand_utils import MersenneTwister
 fn create_linear_regression(
     batch_size: Int,
     n_outputs: Int,
-    linear1_weights: DynamicVector[SIMD[dtype, 1]],
-    linear1_bias: DynamicVector[SIMD[dtype, 1]],
+    linear1_weights: List[SIMD[dtype, 1]],
+    linear1_bias: List[SIMD[dtype, 1]],
 ) -> Graph:
     var g = Graph()
     var x = g.input(TensorShape(batch_size, 13))
@@ -38,14 +38,14 @@ fn create_linear_regression(
 fn run_mojo[
     batch_size: Int,
     n_outputs: Int,
-    linear1_weights: DynamicVector[SIMD[dtype, 1]],
-    linear1_bias: DynamicVector[SIMD[dtype, 1]],
+    linear1_weights: List[SIMD[dtype, 1]],
+    linear1_bias: List[SIMD[dtype, 1]],
 ](
     epochs: Int,
-    learning_rate: FloatLiteral,
+    learning_rate: Float64,
     inputs: Tensor[dtype],
     labels: Tensor[dtype],
-) -> DynamicVector[SIMD[dtype, 1]]:
+) -> List[SIMD[dtype, 1]]:
     alias graph = create_linear_regression(
         batch_size,
         n_outputs,
@@ -57,7 +57,7 @@ fn run_mojo[
     var optim = nn.optim.Adam[graph](lr=learning_rate)
     optim.allocate_rms_and_momentum(model.parameters)
 
-    var losses = DynamicVector[SIMD[dtype, 1]]()
+    var losses = List[SIMD[dtype, 1]]()
 
     for i in range(epochs):
         var loss = model.forward(inputs, labels)
@@ -67,20 +67,20 @@ fn run_mojo[
         model.backward()
         optim.step(model.parameters)
 
-        losses.push_back(loss[0])
+        losses.append(loss[0])
 
     return losses
 
 
 fn run_torch(
     epochs: Int,
-    learning_rate: FloatLiteral,
+    learning_rate: Float64,
     inputs: Tensor,
     labels: Tensor,
     owned linear1_weights: Tensor,
     owned linear1_bias: Tensor,
-) -> DynamicVector[SIMD[dtype, 1]]:
-    var out: DynamicVector[SIMD[dtype, 1]] = DynamicVector[SIMD[dtype, 1]]()
+) -> List[SIMD[dtype, 1]]:
+    var out: List[SIMD[dtype, 1]] = List[SIMD[dtype, 1]]()
 
     try:
         var torch = Python.import_module("torch")
@@ -113,7 +113,7 @@ fn run_torch(
             _ = loss.backward()
             _ = optimizer.step()
 
-            out.push_back(to_tensor(loss)[0].cast[dtype]())
+            out.append(to_tensor(loss)[0].cast[dtype]())
 
         return out
 
@@ -123,21 +123,21 @@ fn run_torch(
         return out
 
 
-fn create_weights(num_elements: Int, zero: Bool) -> DynamicVector[SIMD[dtype, 1]]:
+fn create_weights(num_elements: Int, zero: Bool) -> List[SIMD[dtype, 1]]:
     var prng = MersenneTwister(123456)
-    var weights = DynamicVector[SIMD[dtype, 1]](capacity=num_elements)
+    var weights = List[SIMD[dtype, 1]](capacity=num_elements)
     for i in range(num_elements):
         if zero:
-            weights.push_back(SIMD[dtype, 1](0.0))
+            weights.append(SIMD[dtype, 1](0.0))
         else:
             var rand_float = prng.next().cast[dtype]() / max_finite[DType.int32]().cast[
                 dtype
             ]()
-            weights.push_back(SIMD[dtype, 1](rand_float / 10))
+            weights.append(SIMD[dtype, 1](rand_float / 10))
     return weights ^
 
 
-fn dv_to_tensor(dv: DynamicVector[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
+fn dv_to_tensor(dv: List[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
     var t = Tensor[dtype](shape)
     if t.num_elements() != len(dv):
         print("[WARNING] tensor and dv not the shame shape")

--- a/test/test_tensorutils_data.mojo
+++ b/test/test_tensorutils_data.mojo
@@ -351,13 +351,13 @@ struct TransposeData:
 struct PaddingData:
     var A: Tensor[dtype]
     var expected: Tensor[dtype]
-    var pad_with: DynamicVector[Int]
+    var pad_with: List[Int]
 
     fn __init__(
         inout self,
         A: Tensor[dtype],
         expected: Tensor[dtype],
-        pad_with: DynamicVector[Int],
+        pad_with: List[Int],
     ):
         self.A = A
         self.expected = expected
@@ -368,9 +368,9 @@ struct PaddingData:
         var A = generate_tensor(2)
 
         var expected = StaticIntTuple[4](1, 2, 0, 0)
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(0)  # before
-        pad_with.push_back(2)  # after
+        var pad_with = List[Int]()
+        pad_with.append(0)  # before
+        pad_with.append(2)  # after
 
         var B = generate_expected_tensor(expected, 4)
 
@@ -381,9 +381,9 @@ struct PaddingData:
         var A = generate_tensor(3)
 
         var expected = StaticIntTuple[6](0, 0, 1, 2, 3, 0)
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(2)  # before
-        pad_with.push_back(1)  # after
+        var pad_with = List[Int]()
+        pad_with.append(2)  # before
+        pad_with.append(1)  # after
 
         var B = generate_expected_tensor(expected, 6)
 
@@ -393,7 +393,7 @@ struct PaddingData:
     fn generate_2d_test_case() -> PaddingData:
         var A = generate_tensor(2, 2)
 
-        var expected = StaticTuple[45](
+        var expected = StaticIntTuple[45](
             0,
             0,
             0,
@@ -440,11 +440,11 @@ struct PaddingData:
             0,
             0,
         )
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(1)  # before_1
-        pad_with.push_back(2)  # after_1
-        pad_with.push_back(3)  # before_2
-        pad_with.push_back(4)  # after_2
+        var pad_with = List[Int]()
+        pad_with.append(1)  # before_1
+        pad_with.append(2)  # after_1
+        pad_with.append(3)  # before_2
+        pad_with.append(4)  # after_2
 
         var B = generate_expected_tensor[45](expected, 5, 9)
 
@@ -457,13 +457,13 @@ struct PaddingData:
         var expected = StaticIntTuple[16](
             0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8, 0, 0
         )
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(0)  # before_1
-        pad_with.push_back(0)  # after_1
-        pad_with.push_back(1)  # before_2
-        pad_with.push_back(1)  # after_2
-        pad_with.push_back(0)  # before_3
-        pad_with.push_back(0)  # after_3
+        var pad_with = List[Int]()
+        pad_with.append(0)  # before_1
+        pad_with.append(0)  # after_1
+        pad_with.append(1)  # before_2
+        pad_with.append(1)  # after_2
+        pad_with.append(0)  # before_3
+        pad_with.append(0)  # after_3
 
         var B = generate_expected_tensor[16](expected, 2, 4, 2)
 
@@ -520,13 +520,13 @@ struct PaddingData:
             0,
             0,
         )
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(1)  # before_1
-        pad_with.push_back(1)  # after_1
-        pad_with.push_back(1)  # before_2
-        pad_with.push_back(0)  # after_2
-        pad_with.push_back(0)  # before_3
-        pad_with.push_back(2)  # after_3
+        var pad_with = List[Int]()
+        pad_with.append(1)  # before_1
+        pad_with.append(1)  # after_1
+        pad_with.append(1)  # before_2
+        pad_with.append(0)  # after_2
+        pad_with.append(0)  # before_3
+        pad_with.append(2)  # after_3
 
         var B = generate_expected_tensor[45](expected, 3, 3, 5)
 
@@ -620,15 +620,15 @@ struct PaddingData:
             0,
         )
 
-        var pad_with = DynamicVector[Int]()
-        pad_with.push_back(0)  # before_1
-        pad_with.push_back(1)  # after_1
-        pad_with.push_back(0)  # before_2
-        pad_with.push_back(1)  # after_2
-        pad_with.push_back(0)  # before_3
-        pad_with.push_back(1)  # after_3
-        pad_with.push_back(0)  # before_4
-        pad_with.push_back(1)  # after_4
+        var pad_with = List[Int]()
+        pad_with.append(0)  # before_1
+        pad_with.append(1)  # after_1
+        pad_with.append(0)  # before_2
+        pad_with.append(1)  # after_2
+        pad_with.append(0)  # before_3
+        pad_with.append(1)  # after_3
+        pad_with.append(0)  # before_4
+        pad_with.append(1)  # after_4
 
         var B = generate_expected_tensor[81](expected, 3, 3, 3, 3)
 

--- a/test/test_utils_extras.mojo
+++ b/test/test_utils_extras.mojo
@@ -29,9 +29,9 @@ def to_numpy(tensor: Tensor) -> PythonObject:
 
 
 fn to_tensor(np_array: PythonObject) raises -> Tensor[dtype]:
-    var shape = DynamicVector[Int]()
+    var shape = List[Int]()
     for i in range(np_array.ndim):
-        shape.push_back(np_array.shape[i].to_float64().to_int())
+        shape.append(np_array.shape[i].to_float64().to_int())
 
     var tensor = Tensor[dtype](TensorShape(shape))
 


### PR DESCRIPTION
it seem there is now a little bug where parameters not always correctly resolve with the order of the arguments. Like with the ```load[T: Intable, width: Int, alignment: Int](self: Self, offset: T) -> SIMD[type, width]``` function you need to call it like this ```load[width=simd_width](offset)```, it seems the T type doesn't resolve correctly