### PR TITLE
[BLOCKED] Add CLIP operation

### DIFF
--- a/basalt/autograd/ops/basics.mojo
+++ b/basalt/autograd/ops/basics.mojo
@@ -1,11 +1,12 @@
 from math import add, sub, mul, div, log, exp
 from algorithm import vectorize
 from memory import memcpy
+from math.limit import max_finite
 
 from basalt import Tensor, TensorShape
 from basalt.nn.tensor import max_rank
 from basalt.utils.tensorutils import *
-from basalt.autograd.attributes import Attribute, AttributeVector
+from basalt.autograd.attributes import Attribute, AttributeVector, AttributeValue
 
 """
 Implement forward and backward operations for basic tensor manipulations.
@@ -709,5 +710,67 @@ struct RESHAPE:
         """Backward operation of reshape."""
         var res_grad = Tensor[dtype](t_shape)
         memcpy(res_grad.data(), ug.data(), ug_shape.num_elements())
+
+        return res_grad ^
+
+
+struct CLIP:
+    @staticmethod
+    fn result_shape(t_shape: TensorShape) -> TensorShape:
+        return t_shape
+
+    @staticmethod
+    fn forward[
+        t_shape: TensorShape, attributes: AttributeVector
+    ](inout res: Tensor[dtype], t: Tensor[dtype]):
+        """
+        Forward pass of the clip operation.
+        """
+        alias min_attr = attributes["min"]
+        alias max_attr = attributes["max"]
+
+        var min_val = min_attr.or_else(
+            AttributeValue(-max_finite[dtype]())
+        ).to_int()
+        var max_val = max_attr.or_else(
+            AttributeValue(max_finite[dtype]())
+        ).to_int()
+
+        @parameter
+        fn vec_clip[Nelts: Int](i: Int):
+            res.store[Nelts](i, t.load[Nelts](i).min(max_val).max(min_val))
+
+        vectorize[vec_clip, nelts, size = t_shape.num_elements()]()
+
+    @staticmethod
+    fn backward[
+        ug_shape: TensorShape,
+        t_shape: TensorShape,
+        attributes: AttributeVector
+    ](ug: Tensor[dtype], t: Tensor[dtype]) -> Tensor[
+        dtype
+    ]:
+        """Backward operation of clip."""
+        alias min_attr = attributes["min"]
+        alias max_attr = attributes["max"]
+
+        var min_val = min_attr.or_else(
+            AttributeValue(-max_finite[dtype]())
+        ).to_int()
+        var max_val = max_attr.or_else(
+            AttributeValue(max_finite[dtype]())
+        ).to_int()
+
+        var res_grad = Tensor[dtype](t_shape)
+
+        @parameter
+        fn vec_clip_bw[Nelts: Int](i: Int):
+            var val = t.load[Nelts](i)
+            res_grad.store[Nelts](
+                i,
+                (val >= min_val and val <= max_val).select(ug.load[Nelts](i), 0),
+            )
+
+        vectorize[vec_clip_bw, nelts, size = t_shape.num_elements()]()
 
         return res_grad ^

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -3,7 +3,7 @@ from math import exp, pow
 
 from basalt import Tensor, TensorShape
 from basalt.utils.tensorutils import elwise_transform
-
+from basalt.autograd.attributes import Attribute, AttributeVector, AttributeValue
 
 @value
 struct SIGMOID:
@@ -145,6 +145,68 @@ struct TANH:
         vectorize[vec_tanh_bw, nelts](ug_shape.num_elements())
 
         return res_grad ^
+
+struct CLIP:
+    @staticmethod
+    fn result_shape(t_shape: TensorShape) -> TensorShape:
+        return t_shape
+
+    @staticmethod
+    fn forward[
+        t_shape: TensorShape, attributes: AttributeVector
+    ](inout res: Tensor[dtype], t: Tensor[dtype]):
+        """
+        Forward pass of the clip operation.
+        """
+        alias min_attr = attributes["min"]
+        alias max_attr = attributes["max"]
+
+        var min_val = min_attr.or_else(
+            AttributeValue(-SIMD[dtype].MAX_FINITE)
+        ).to_int()
+        var max_val = max_attr.or_else(
+            AttributeValue(SIMD[dtype].MAX_FINITE)
+        ).to_int()
+
+        @parameter
+        fn vec_clip[Nelts: Int](i: Int):
+            res.store[Nelts](i, t.load[Nelts](i).min(max_val).max(min_val))
+
+        vectorize[vec_clip, nelts, size = t_shape.num_elements()]()
+
+    @staticmethod
+    fn backward[
+        ug_shape: TensorShape,
+        t_shape: TensorShape,
+        attributes: AttributeVector = AttributeVector()
+    ](ug: Tensor[dtype], t: Tensor[dtype]) -> Tensor[
+        dtype
+    ]:
+        """Backward operation of clip."""
+        alias min_attr = attributes["min"]
+        alias max_attr = attributes["max"]
+
+        var min_val = min_attr.or_else(
+            AttributeValue(-SIMD[dtype].MAX_FINITE)
+        ).to_int()
+        var max_val = max_attr.or_else(
+            AttributeValue(SIMD[dtype].MAX_FINITE)
+        ).to_int()
+
+        var res_grad = Tensor[dtype](t_shape)
+
+        @parameter
+        fn vec_clip_bw[Nelts: Int](i: Int):
+            var val = t.load[Nelts](i)
+            res_grad.store[Nelts](
+                i,
+                (val >= min_val and val <= max_val).select(ug.load[Nelts](i), 0),
+            )
+
+        vectorize[vec_clip_bw, nelts, size = t_shape.num_elements()]()
+
+        return res_grad ^
+
 
 
 # struct SOFTMAX:

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -13,6 +13,7 @@ from .basics import (
     FLATTEN,
     RESHAPE,
     TRANSPOSE,
+    CLIP,
 )
 from .mlops import SIGMOID, RELU, TANH
 from .conv import CONV2D
@@ -51,6 +52,7 @@ struct OP(Stringable):
     alias CONV2D = OP(16, "CONV2D", num_operands=3)
     alias TRANSPOSE = OP(17, "TRANSPOSE", num_operands=1)
     alias MAXPOOL2D = OP(18, "MAXPOOL2D", num_operands=1)
+    alias CLIP = OP(19, "CLIP", num_operands=1)
 
     var id: UInt8
     var name: bytes[16]
@@ -98,6 +100,8 @@ fn static_result_shape(
         return TRANSPOSE.result_shape(t1_shape, attributes)
     elif op == OP.MAXPOOL2D:
         return MAXPOOL2D.result_shape(t1_shape, attributes)
+    elif op == OP.CLIP:
+        return CLIP.result_shape(t1_shape)
     else:
         print("[ERROR] Operator not found.")
         return TensorShape(-1)
@@ -180,6 +184,8 @@ fn forward_op[
         TRANSPOSE.forward[t1_shape, attributes](res, t1)
     elif op == OP.MAXPOOL2D:
         MAXPOOL2D.forward[t1_shape, attributes](res, t1)
+    elif op == OP.CLIP:
+        CLIP.forward[t1_shape, attributes](res, t1)
     else:
         print("[ERROR] Operator not found.")
 
@@ -263,6 +269,8 @@ fn backward_op[
         res_grad = TRANSPOSE.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.MAXPOOL2D:
         res_grad = MAXPOOL2D.backward[ug_shape, t1_shape, attributes](ug, t1)
+    elif op == OP.CLIP:
+        res_grad = CLIP.backward[ug_shape, t1_shape, attributes](ug, t1)
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1)

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -13,9 +13,8 @@ from .basics import (
     FLATTEN,
     RESHAPE,
     TRANSPOSE,
-    CLIP,
 )
-from .mlops import SIGMOID, RELU, TANH
+from .mlops import SIGMOID, RELU, TANH, CLIP
 from .conv import CONV2D
 from .pool import MAXPOOL2D
 

--- a/test/test_mlops.mojo
+++ b/test/test_mlops.mojo
@@ -6,7 +6,7 @@ from test_tensorutils import assert_tensors_equal
 import basalt.nn as nn
 from basalt import Tensor, TensorShape
 from basalt import Graph, Symbol, OP
-from basalt.autograd.ops.mlops import SIGMOID, RELU, TANH
+from basalt.autograd.ops.mlops import SIGMOID, RELU, TANH, CLIP
 from basalt.utils.tensorutils import fill
 
 
@@ -124,12 +124,40 @@ fn test_backward_TANH() raises:
     var grad = TANH.backward[ug_shape, t1_shape](ug, t1)
     assert_tensors_equal(grad, expected_grad)
 
+fn test_CLIP() raises:
+    alias t1_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(6):
+        t1[i] = i
+
+    var expected = Tensor[dtype](2, 3)
+    for i in range(6):
+        expected[i] = i
+
+    test_unary_op[OP.CLIP, t1_shape](t1, expected)
+
+fn test_backwards_CLIP() raises:
+    alias t1_shape = TensorShape(2, 3)
+    alias ug_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
+    for i in range(6):
+        t1[i] = i
+    fill(ug, 5.0)
+
+    var expected_grad = Tensor[dtype](2, 3)
+    fill(expected_grad, 5.0)
+
+    var grad = CLIP.backward[ug_shape, t1_shape](ug, t1)
+    assert_tensors_equal(grad, expected_grad)
+
 
 fn main():
     try:
         test_SIGMOID()
         test_RELU()
         test_TANH()
+        test_CLIP()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
@@ -139,6 +167,7 @@ fn main():
         test_backward_SIGMOID()
         test_backward_RELU()
         test_backward_TANH()
+        test_backwards_CLIP()
     except e:
         print("[ERROR] Error in backward mlops")
         print(e)

--- a/test/test_mlops_torch.mojo
+++ b/test/test_mlops_torch.mojo
@@ -38,6 +38,8 @@ fn torch_unary_op(op: OP, input_1: Tensor, upper_grad: Tensor) -> torch_output_u
             expected = torch.relu(input_1)
         elif op == OP.TANH:
             expected = torch.tanh(input_1)
+        elif op == OP.CLIP:
+            expected = torch.clamp(input_1, 0, 1)
         else:
             print("Error: op not supported (returning the value input_1): ", op)
             expected = input_1
@@ -121,6 +123,17 @@ fn test_TANH() raises:
 
     var expected_and_grad = torch_unary_op(OP.TANH, t1, ug)
 
+fn test_CLIP() raises:
+    alias t1_shape = TensorShape(37, 63, 107)
+    alias ug_shape = TensorShape(37, 63, 107)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    rand(t1.data(), t1.num_elements())
+
+    var ug = Tensor[dtype](ug_shape)
+    rand(ug.data(), ug.num_elements())
+
+    var expected_and_grad = torch_unary_op(OP.CLIP, t1, ug)
+
 
 fn main():
     print("Running mlops (compare with torch) tests")
@@ -128,6 +141,7 @@ fn main():
         test_SIGMOID()
         test_RELU()
         test_TANH()
+        test_CLIP()
     except e:
         print("[ERROR] Error in mlops (compare with torch)")
         print(e)

--- a/test/test_ops.mojo
+++ b/test/test_ops.mojo
@@ -429,33 +429,6 @@ fn test_RESHAPE() raises:
 
     assert_tensors_equal(res, expected)
 
-fn test_CLIP() raises:
-    alias t_shape = TensorShape(2, 3)
-    var t = Tensor[dtype](t_shape)
-    fill(t, 10)
-
-    fn create_graph() -> Graph:
-        var g = Graph()
-        var t1 = g.input(t_shape)
-
-        var res = g.op(
-            OP.CLIP, t1, attributes=AttributeVector(Attribute("min", 0), Attribute("max", 5))
-        )
-        g.out(res)
-
-        return g ^
-
-    alias graph = create_graph()
-    assert_equal(len(graph.nodes), 1)
-    var model = nn.Model[graph](inference_only=True)
-    var res = model.inference(t)[0]
-
-    var expected = Tensor[dtype](2, 3)
-    fill(expected, 5)
-
-    assert_tensors_equal(res, expected)
-
-
 fn main():
     try:
         test_ADD()
@@ -472,7 +445,6 @@ fn main():
         test_TRANSPOSE()
         test_FLATTEN()
         test_RESHAPE()
-        test_CLIP()
     except e:
         print("[ERROR] Error in ops")
         print(e)

--- a/test/test_ops.mojo
+++ b/test/test_ops.mojo
@@ -429,6 +429,32 @@ fn test_RESHAPE() raises:
 
     assert_tensors_equal(res, expected)
 
+fn test_CLIP() raises:
+    alias t_shape = TensorShape(2, 3)
+    var t = Tensor[dtype](t_shape)
+    fill(t, 10)
+
+    fn create_graph() -> Graph:
+        var g = Graph()
+        var t1 = g.input(t_shape)
+
+        var res = g.op(
+            OP.CLIP, t1, attributes=AttributeVector(Attribute("min", 0), Attribute("max", 5))
+        )
+        g.out(res)
+
+        return g ^
+
+    alias graph = create_graph()
+    assert_equal(len(graph.nodes), 1)
+    var model = nn.Model[graph](inference_only=True)
+    var res = model.inference(t)[0]
+
+    var expected = Tensor[dtype](2, 3)
+    fill(expected, 5)
+
+    assert_tensors_equal(res, expected)
+
 
 fn main():
     try:
@@ -446,6 +472,7 @@ fn main():
         test_TRANSPOSE()
         test_FLATTEN()
         test_RESHAPE()
+        test_CLIP()
     except e:
         print("[ERROR] Error in ops")
         print(e)


### PR DESCRIPTION
This pull request adds a new CLIP operation to the codebase. The CLIP operation allows for clipping the values of a tensor within a specified range. This can be useful for tasks such as gradient clipping in neural networks.