### PR TITLE
Attributes accepting Scalars

### DIFF
--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -8,16 +8,13 @@ struct bytes[capacity: Int](Stringable, CollectionElement):
     Static sequence of bytes.
     """
 
-    var _vector: StaticTuple[UInt8, capacity]
+    var _vector: SIMD[DType.uint8, capacity]
 
     fn __init__(inout self):
-        var _vector = StaticTuple[UInt8, capacity]()
-        for i in range(capacity):
-            _vector[i] = 0
-        self._vector = _vector
+        self._vector = SIMD[DType.uint8, capacity]()
 
     fn __init__(inout self, s: String):
-        var _vector = StaticTuple[UInt8, capacity]()
+        var _vector = SIMD[DType.uint8, capacity]()
         for i in range(min(len(s), capacity)):
             _vector[i] = ord(s[i])
         self._vector = _vector

--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -8,13 +8,14 @@ struct bytes[capacity: Int](Stringable, CollectionElement):
     Static sequence of bytes.
     """
 
-    var _vector: SIMD[DType.uint8, capacity]
+    # var _vector: SIMD[DType.uint8, capacity]
+    var _vector: StaticTuple[UInt8, capacity]
 
     fn __init__(inout self):
-        self._vector = SIMD[DType.uint8, capacity]()
+        self._vector = StaticTuple[UInt8, capacity]()
 
     fn __init__(inout self, s: String):
-        var _vector = SIMD[DType.uint8, capacity]()
+        var _vector = StaticTuple[UInt8, capacity]()
         for i in range(min(len(s), capacity)):
             _vector[i] = ord(s[i])
         self._vector = _vector


### PR DESCRIPTION
- Reworking attributes to accepts scalar values of a given dtype
- Unblocking: CLIP: https://github.com/basalt-org/basalt/pull/44

NOTE: The current implementation of AttributeValue is a workaround.
Can't seem find a way so far to support attributes of Variant types that are able to pass through the information from comp time to the ops. Limited bytes support requires a custom bytes implementation.