### PR TITLE
Simplified conversion to f64

### DIFF
--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -62,11 +62,11 @@ fn f64_to_bytes[size: Int = DType.float64.sizeof()](value: Scalar[DType.float64]
     alias mantissa_bits = 52
     alias exponent_bias = 1023
 
-    var sign = 0 if value >= 0 else 1
-    var abs = value if value >= 0 else -value
+    var sign: Int64 = 0 if value >= 0 else 1
+    var abs: Float64 = value if value >= 0 else -value
 
-    var mantissa = 0.0
-    var exponent = exponent_bias
+    var mantissa: Float64 = 0.0
+    var exponent: Int64 = exponent_bias
 
     if value == 0.0:
         exponent = 0
@@ -81,16 +81,18 @@ fn f64_to_bytes[size: Int = DType.float64.sizeof()](value: Scalar[DType.float64]
 
         mantissa = (abs - 1.0) * (1 << mantissa_bits)
 
-    var binary_rep = (sign << (exponent_bits + mantissa_bits)) | (
-        exponent << mantissa_bits
-    ) | int(mantissa)
+    var binary_rep: Int64 = 0
+
+    binary_rep |= sign << (exponent_bits + mantissa_bits)
+    binary_rep |= exponent << mantissa_bits
+    binary_rep |= mantissa
 
     var result = Bytes[size]()
 
     @parameter
     fn fill_bytes[Index: Int]():
-        alias Offest = Index * 8
-        result[Index] = (binary_rep >> Offest) & 0xFF
+        alias Offest: Int64 = Index * 8
+        result[Index] = (binary_rep >> Offest).to_int() & 0xFF
 
     unroll[fill_bytes, size]()
 

--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -54,138 +54,79 @@ struct Bytes[capacity: Int](Stringable, CollectionElement):
 
 
 @always_inline("nodebug")
-fn float_to_bytes[
-    dtype: DType, size: Int = dtype.sizeof()
-](value: Scalar[dtype]) -> Bytes[size]:
+fn f64_to_bytes[size: Int = DType.float64.sizeof()](value: Scalar[DType.float64]) -> Bytes[size]:
     """
-    Convert a floating point number to a sequence of bytes in IEEE 754 format.
-    Supported byte sizes are 2 (f16), 4 (f32) and 8 (f64) bytes.
+    Convert a f64 number to a sequence of bytes in IEEE 754 format.
     """
+    alias exponent_bits = 11
+    alias mantissa_bits = 52
+    alias exponent_bias = 1023
 
-    fn compute_bytes[
-        dtype: DType,
-        size: Int,
-        exponent_bits: Int,
-        mantissa_bits: Int,
-        exponent_bias: Int,
-    ](value: Scalar[dtype]) -> Bytes[size]:
-        var sign = 0 if value >= 0 else 1
-        var abs = value if value >= 0 else -value
+    var sign = 0 if value >= 0 else 1
+    var abs = value if value >= 0 else -value
 
-        var mantissa: Scalar[dtype] = 0
-        var exponent = exponent_bias
+    var mantissa = 0.0
+    var exponent = exponent_bias
 
-        if value == 0.0:
-            exponent = 0
-            mantissa = 0
-        else:
-            while abs >= 2.0:
-                abs /= 2.0
-                exponent += 1
-            while abs < 1.0:
-                abs *= 2.0
-                exponent -= 1
+    if value == 0.0:
+        exponent = 0
+        mantissa = 0
+    else:
+        while abs >= 2.0:
+            abs /= 2.0
+            exponent += 1
+        while abs < 1.0:
+            abs *= 2.0
+            exponent -= 1
 
-            mantissa = (abs - 1.0) * (1 << mantissa_bits)
+        mantissa = (abs - 1.0) * (1 << mantissa_bits)
 
-        var binary_rep = (sign << (exponent_bits + mantissa_bits)) | (
-            exponent << mantissa_bits
-        ) | int(mantissa)
+    var binary_rep = (sign << (exponent_bits + mantissa_bits)) | (
+        exponent << mantissa_bits
+    ) | int(mantissa)
 
-        var result = Bytes[size]()
-        for i in range(size):
-            result[i] = (binary_rep >> (8 * i)) & 0xFF
-
-        return result
+    var result = Bytes[size]()
 
     @parameter
-    if dtype == DType.float16:
-        alias exponent_bits = 5
-        alias mantissa_bits = 10
-        alias exponent_bias = 15
-        return compute_bytes[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            value
-        )
-    elif dtype == DType.float32:
-        alias exponent_bits = 8
-        alias mantissa_bits = 23
-        alias exponent_bias = 127
-        return compute_bytes[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            value
-        )
-    elif dtype == DType.float64:
-        alias exponent_bits = 11
-        alias mantissa_bits = 52
-        alias exponent_bias = 1023
-        return compute_bytes[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            value
-        )
-    else:
-        constrained[False, "must be eiter float16, float32 or float64"]()
-        return Bytes[size]()
+    fn fill_bytes[Index: Int]():
+        alias Offest = Index * 8
+        result[Index] = (binary_rep >> Offest) & 0xFF
+
+    unroll[fill_bytes, size]()
+
+    return result
 
 
-fn bytes_to_float[
-    dtype: DType, size: Int = dtype.sizeof()
-](bytes: Bytes[size]) -> Scalar[dtype]:
+fn bytes_to_f64[size: Int = DType.float64.sizeof()](bytes: Bytes[size]) -> Scalar[DType.float64]:
     """
     Convert a sequence of bytes in IEEE 754 format to a floating point number.
     Supported byte sizes are 2 (f16), 4 (f32) and 8 (f64) bytes.
     """
 
-    fn compute_float[
-        dtype: DType,
-        size: Int,
-        exponent_bits: Int,
-        mantissa_bits: Int,
-        exponent_bias: Int,
-    ](bytes: Bytes[size]) -> Scalar[dtype]:
-        var binary_rep = 0
+    alias exponent_bits = 11
+    alias mantissa_bits = 52
+    alias exponent_bias = 1023
 
-        @parameter
-        fn to_bin[Index: Int]():
-            alias Offest = Index * 8
-            binary_rep |= bytes[Index].to_int() << Offest
-
-        unroll[to_bin, size]()
-
-        var sign = (-1) ** ((binary_rep >> (exponent_bits + mantissa_bits)) & 1)
-        var exponent = (
-            (binary_rep >> mantissa_bits) & ((1 << exponent_bits) - 1)
-        ) - exponent_bias
-        var mantissa = (binary_rep & ((1 << mantissa_bits) - 1)) / (
-            1 << mantissa_bits
-        ) + (exponent != -exponent_bias)
-
-        if exponent == exponent_bias + 1:
-            return inf[dtype]() if mantissa == 0 else nan[dtype]()
-        elif exponent == -exponent_bias and mantissa == 0:
-            return 0.0
-        else:
-            return sign * (2**exponent) * mantissa
+    var binary_rep = 0
 
     @parameter
-    if dtype == DType.float16:
-        alias exponent_bits = 5
-        alias mantissa_bits = 10
-        alias exponent_bias = 15
-        return compute_float[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            bytes
-        )
-    elif dtype == DType.float32:
-        alias exponent_bits = 8
-        alias mantissa_bits = 23
-        alias exponent_bias = 127
-        return compute_float[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            bytes
-        )
-    elif dtype == DType.float64:
-        alias exponent_bits = 11
-        alias mantissa_bits = 52
-        alias exponent_bias = 1023
-        return compute_float[dtype, size, exponent_bits, mantissa_bits, exponent_bias](
-            bytes
-        )
-    else:
-        constrained[False, "must be eiter float16, float32 or float64"]()
+    fn to_bin[Index: Int]():
+        alias Offest = Index * 8
+        binary_rep |= bytes[Index].to_int() << Offest
+
+    unroll[to_bin, size]()
+
+    var sign = (-1) ** ((binary_rep >> (exponent_bits + mantissa_bits)) & 1)
+    var exponent = (
+        (binary_rep >> mantissa_bits) & ((1 << exponent_bits) - 1)
+    ) - exponent_bias
+    var mantissa = (binary_rep & ((1 << mantissa_bits) - 1)) / (
+        1 << mantissa_bits
+    ) + (exponent != -exponent_bias)
+
+    if exponent == exponent_bias + 1:
+        return inf[DType.float64]() if mantissa == 0 else nan[DType.float64]()
+    elif exponent == -exponent_bias and mantissa == 0:
         return 0.0
+    else:
+        return sign * (2**exponent) * mantissa

--- a/basalt/utils/bytes.mojo
+++ b/basalt/utils/bytes.mojo
@@ -102,7 +102,6 @@ fn f64_to_bytes[size: Int = DType.float64.sizeof()](value: Scalar[DType.float64]
 fn bytes_to_f64[size: Int = DType.float64.sizeof()](bytes: Bytes[size]) -> Scalar[DType.float64]:
     """
     Convert a sequence of bytes in IEEE 754 format to a floating point number.
-    Supported byte sizes are 2 (f16), 4 (f32) and 8 (f64) bytes.
     """
 
     alias exponent_bits = 11

--- a/test/test_attributes.mojo
+++ b/test/test_attributes.mojo
@@ -43,16 +43,16 @@ fn test_attribute_static_int_tuple() raises:
     
     
 fn test_attribute_scalar() raises:
-    var value_a: Scalar[DType.float32] = Scalar[DType.float32](1.23456)
-    var a = Attribute(name="test", value=value_a)
+    alias value_a: Float32 = 1.23456
+    alias a = Attribute(name="test", value=value_a)
     assert_true(a.to_scalar[DType.float32]() == value_a, "Float32 scalar attribute failed")
     
-    var value_b: Scalar[DType.float64] = Scalar[DType.float64](-1.23456)
-    var b = Attribute(name="test", value=value_b)
+    alias value_b: Float64 = -1.23456
+    alias b = Attribute(name="test", value=value_b)
     assert_true(b.to_scalar[DType.float64]() == value_b, "Float64 scalar attribute failed")
 
-    var value_c: Scalar[DType.int32] = Scalar[DType.int32](666)
-    var c = Attribute(name="test", value=value_c)
+    alias value_c: Int32 = 666
+    alias c = Attribute(name="test", value=value_c)
     assert_true(c.to_scalar[DType.int32]() == value_c, "Int32 scalar attribute failed")
 
 


### PR DESCRIPTION
This pull requests changes the logic for Scalars by simply casting to an f64 for any value, then storing them all that way. Since this is compile time, performance doesn't matter, and this method should work for any DType value currently in the stdlib.