### PR TITLE
CONCAT2 Operator

### DIFF
--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -78,8 +78,11 @@ struct Graph:
         operand_3: Optional[Symbol] = None,
         attributes: AttributeVector = AttributeVector(),
     ) -> Symbol:
+        # TODO: Check if this can be *operands: Symbol
         var res: Symbol
+        var inputs: List[Symbol]
         if operand_3:
+            inputs = List[Symbol](operand_1, operand_2.value(), operand_3.value())
             res = Symbol(
                 self.symbol_count,
                 dtype,
@@ -93,6 +96,7 @@ struct Graph:
                 self.result_trainable(operand_1, operand_2.value(), operand_3.value()),
             )
         elif operand_2:
+            inputs = List[Symbol](operand_1, operand_2.value())
             res = Symbol(
                 self.symbol_count,
                 dtype,
@@ -102,6 +106,7 @@ struct Graph:
                 self.result_trainable(operand_1, operand_2.value()),
             )
         else:
+            inputs = List[Symbol](operand_1)
             res = Symbol(
                 self.symbol_count,
                 dtype,
@@ -109,7 +114,8 @@ struct Graph:
                 self.result_trainable(operand_1),
             )
 
-        self.nodes.append(Node(op, res, operand_1, operand_2, operand_3, attributes))
+        var outputs = List[Symbol](res)
+        self.nodes.append(Node(op, inputs, outputs, attributes))
         self.symbol_count += 1
         return res
 

--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -93,8 +93,7 @@ struct Graph:
         var inputs = List[Symbol]()
         for operand in operands:
             inputs.append(operand)
-        var outputs = List[Symbol](res)
-        self.nodes.append(Node(op, inputs, outputs, attributes))
+        self.nodes.append(Node(op, inputs, res, attributes))
         return res
 
     fn op(

--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -121,20 +121,7 @@ struct Graph:
         attributes: AttributeVector = AttributeVector(),
     ) -> Symbol:
         var operand_2_symbol = self.scalar(operand_2)
-        var res = Symbol(
-            self.symbol_count,
-            dtype,
-            static_result_shape(
-                op, operand_1.shape, operand_2_symbol.shape, attributes
-            ),
-            self.result_trainable(operand_1),
-        )
-
-        self.nodes.append(
-            Node(op, res, operand_1, operand_2_symbol, attributes=attributes)
-        )
-        self.symbol_count += 1
-        return res
+        return self.op(op, operand_1, operand_2_symbol, attributes=attributes)
 
     fn op(
         inout self,
@@ -144,34 +131,14 @@ struct Graph:
         attributes: AttributeVector = AttributeVector(),
     ) -> Symbol:
         var operand_1_symbol = self.scalar(operand_1)
-        var res = Symbol(
-            self.symbol_count,
-            dtype,
-            static_result_shape(
-                op, operand_1_symbol.shape, operand_2.shape, attributes
-            ),
-            self.result_trainable(operand_2),
-        )
-
-        self.nodes.append(
-            Node(op, res, operand_1_symbol, operand_2, attributes=attributes)
-        )
-        self.symbol_count += 1
-        return res
+        return self.op(op, operand_1_symbol, operand_2, attributes=attributes)
 
     @staticmethod
-    fn result_trainable(operand_1: Symbol) -> Bool:
-        return operand_1.trainable
-
-    @staticmethod
-    fn result_trainable(operand_1: Symbol, operand_2: Symbol) -> Bool:
-        return operand_1.trainable or operand_2.trainable
-
-    @staticmethod
-    fn result_trainable(
-        operand_1: Symbol, operand_2: Symbol, operand_3: Symbol
-    ) -> Bool:
-        return operand_1.trainable or operand_2.trainable or operand_3.trainable
+    fn result_trainable(*operands: Symbol) -> Bool:
+        for operand in operands:
+            if operand.trainable:
+                return True
+        return False
 
     fn json(self) -> String:
         var result: String = '{"graph_name": "basalt", "nodes": ['

--- a/basalt/autograd/node.mojo
+++ b/basalt/autograd/node.mojo
@@ -11,19 +11,19 @@ from .attributes import AttributeVector
 struct Node(CollectionElement, Stringable):
     var operator: OP
     var inputs: List[Symbol]
-    var outputs: List[Symbol]
+    var output: Symbol
     var attributes: AttributeVector
 
     fn __init__(
         inout self,
         operator: OP,
         inputs: List[Symbol],
-        outputs: List[Symbol],
+        output: Symbol,
         attributes: AttributeVector = AttributeVector(),
     ):
         self.operator = operator
         self.inputs = inputs
-        self.outputs = outputs
+        self.output = output
         self.attributes = attributes
 
     fn __str__(self) -> String:
@@ -36,9 +36,5 @@ struct Node(CollectionElement, Stringable):
             if i < len(self.inputs) - 1:
                 s += ", "
         s += '], "outputs": ['
-        for i in range(len(self.outputs)):
-            s += self.outputs[i].json()
-            if i < len(self.outputs) - 1:
-                s += ", "
-        s += "]}"
+        s += self.output.json() + "]}"
         return s

--- a/basalt/autograd/node.mojo
+++ b/basalt/autograd/node.mojo
@@ -13,7 +13,7 @@ struct Node(CollectionElement, Stringable):
     var inputs: List[Symbol]
     var outputs: List[Symbol]
     var attributes: AttributeVector
-    
+
     fn __init__(
         inout self,
         operator: OP,

--- a/basalt/autograd/node.mojo
+++ b/basalt/autograd/node.mojo
@@ -10,26 +10,20 @@ from .attributes import AttributeVector
 @value
 struct Node(CollectionElement, Stringable):
     var operator: OP
-    var output: Symbol
-    var input_1: Symbol
-    var input_2: Optional[Symbol]
-    var input_3: Optional[Symbol]
+    var inputs: List[Symbol]
+    var outputs: List[Symbol]
     var attributes: AttributeVector
-
+    
     fn __init__(
         inout self,
         operator: OP,
-        output: Symbol,
-        input_1: Symbol,
-        input_2: Optional[Symbol] = None,
-        input_3: Optional[Symbol] = None,
+        inputs: List[Symbol],
+        outputs: List[Symbol],
         attributes: AttributeVector = AttributeVector(),
     ):
         self.operator = operator
-        self.output = output
-        self.input_1 = input_1
-        self.input_2 = input_2
-        self.input_3 = input_3
+        self.inputs = inputs
+        self.outputs = outputs
         self.attributes = attributes
 
     fn __str__(self) -> String:
@@ -37,11 +31,14 @@ struct Node(CollectionElement, Stringable):
 
     fn json(self) -> String:
         var s: String = '{"operator": "' + str(self.operator.name) + '", "inputs": ['
-        s += self.input_1.json()
-        if self.input_2:
-            s += ", " + self.input_2.value().json()
-        if self.input_3:
-            s += ", " + self.input_3.value().json()
+        for i in range(len(self.inputs)):
+            s += self.inputs[i].json()
+            if i < len(self.inputs) - 1:
+                s += ", "
         s += '], "outputs": ['
-        s += self.output.json() + "]}"
+        for i in range(len(self.outputs)):
+            s += self.outputs[i].json()
+            if i < len(self.outputs) - 1:
+                s += ", "
+        s += "]}"
         return s

--- a/basalt/autograd/ops/basics.mojo
+++ b/basalt/autograd/ops/basics.mojo
@@ -718,7 +718,8 @@ struct FMA:
     fn result_shape(
         t1_shape: TensorShape, t2_shape: TensorShape, t3_shape: TensorShape
     ) -> TensorShape:
-        return broadcast_shapes(t1_shape, t2_shape, t3_shape)
+        # FMA assumes: t1_shape == t2_shape == t3_shape
+        return t1_shape
 
     @staticmethod
     fn forward[
@@ -736,9 +737,9 @@ struct FMA:
         """
 
         @parameter
-        fn vec_fma[Nelts: Int](i: Int):
-            res.store[Nelts](
-                i, t1.load[Nelts](i).fma(t2.load[Nelts](i), t3.load[Nelts](i))
+        fn vec_fma[nelts: Int](i: Int):
+            res.store[nelts](
+                i, t1.load[nelts](i).fma(t2.load[nelts](i), t3.load[nelts](i))
             )
 
         vectorize[vec_fma, nelts, size = t1_shape.num_elements()]()

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -331,35 +331,3 @@ struct CONCAT2:
             var t2_grad = Tensor[dtype](t2_shape)
             memcpy(t2_grad.data(), ug.data() + t1.num_elements(), t2.num_elements())
             return t2_grad ^
-
-
-# struct SOFTMAX:
-#     @staticmethod
-#     fn softmax[axis: Int](n: Tensor[dtype]) -> Tensor[dtype]:
-#         """Softmax operation."""
-#         # exp(x_i - max(x_j)) / sum(exp(x_j))
-#         var max_val = tmax[dtype, nelts](n, axis)
-#         var x_minus_max = elwise_op[dtype, nelts, sub](n, max_val)
-
-#         var exp_res = elwise_transform[dtype, nelts, exp](x_minus_max)
-#         var sum_res = tsum[dtype, nelts](exp_res, axis)
-#         var res = elwise_op[dtype, nelts, div](exp_res, sum_res)
-
-#         return res
-
-#     @staticmethod
-#     fn forward[axis: Int](n: Node[dtype]) -> Node[dtype]:
-#         """Forward operation of softmax."""
-#         # softmax: exp(x_i) / sum(exp(x_j))
-#         # stable softmax: exp(x_i - max(x_j)) / sum(exp(x_j))
-#         var softmax_res = Self.softmax[axis](n.tensor)
-#         var res = elwise_op[dtype, nelts, div](n.tensor, softmax_res)
-
-#         return GRAPH.create_graph_node[Self.backward[axis]](res, n)
-
-#     @staticmethod
-#     fn backward[axis: Int](
-#         ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int
-#     ) -> Tensor[dtype]:
-#         """Backward operation of softmax."""
-#         pass

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -217,7 +217,9 @@ struct SQUEEZE:
 
         var new_shape = List[Int]()
         for i in range(t1_shape.rank()):
-            if (not dim and t1_shape[i] == 1) or (i in dims_to_squeeze and t1_shape[i] == 1): 
+            if (not dim and t1_shape[i] == 1) or (
+                i in dims_to_squeeze and t1_shape[i] == 1
+            ):
                 continue
             new_shape.append(t1_shape[i])
 
@@ -279,7 +281,9 @@ struct UNSQUEEZE:
 
 struct CONCAT2:
     @staticmethod
-    fn result_shape(t1_shape: TensorShape, t2_shape: TensorShape, attributes: AttributeVector) -> TensorShape:
+    fn result_shape(
+        t1_shape: TensorShape, t2_shape: TensorShape, attributes: AttributeVector
+    ) -> TensorShape:
         # Assumptions: all tensors have the same shape, except for the dimension specified, or are empty
         var dim = attributes["dims"].value().to_int() if attributes["dims"] else 0
 

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -352,8 +352,7 @@ fn backward_op[
             op == OP.ADD or
             op == OP.SUB or 
             op == OP.MUL or
-            op == OP.DIV or
-            op == OP.FMA
+            op == OP.DIV
         )    
     
     @parameter

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -347,9 +347,18 @@ fn backward_op[
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1, -1)
 
+    fn broadcastable(op: OP) -> Bool:
+        return (
+            op == OP.ADD or
+            op == OP.SUB or 
+            op == OP.MUL or
+            op == OP.DIV or
+            op == OP.FMA
+        )    
+    
     @parameter
     if tensor_id == 0:
-        alias res_grad_shape = t1_shape if op == OP.DOT else broadcast_shapes(
+        alias res_grad_shape = t1_shape if not broadcastable(op) else broadcast_shapes(
             t1_shape, t2_shape
         )
         # grad_shape = t1_shape
@@ -359,7 +368,7 @@ fn backward_op[
         accumulate_grad[t1_shape, res_grad_shape](grad, res_grad)
 
     elif tensor_id == 1:
-        alias res_grad_shape = t2_shape if op == OP.DOT else broadcast_shapes(
+        alias res_grad_shape = t2_shape if not broadcastable(op) else broadcast_shapes(
             t1_shape, t2_shape
         )
         # grad_shape = t2_shape

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,15 +15,7 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import (
-    SIGMOID,
-    RELU,
-    TANH,
-    CLIP,
-    SQUEEZE,
-    UNSQUEEZE,
-    CONCAT2,
-)
+from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, CONCAT2
 from .conv import CONV2D
 from .pool import MAXPOOL2D
 
@@ -348,13 +340,8 @@ fn backward_op[
         res_grad = Tensor[dtype](-1, -1)
 
     fn broadcastable(op: OP) -> Bool:
-        return (
-            op == OP.ADD or
-            op == OP.SUB or 
-            op == OP.MUL or
-            op == OP.DIV
-        )    
-    
+        return op == OP.ADD or op == OP.SUB or op == OP.MUL or op == OP.DIV
+
     @parameter
     if tensor_id == 0:
         alias res_grad_shape = t1_shape if not broadcastable(op) else broadcast_shapes(

--- a/basalt/nn/layers/conv.mojo
+++ b/basalt/nn/layers/conv.mojo
@@ -8,7 +8,7 @@ from basalt.autograd.attributes import AttributeVector, Attribute
 
 @always_inline("nodebug")
 fn q_sqrt(value: Float32) -> Float32:
-    var y = bitcast[DType.float32](0x5f3759df - (bitcast[DType.uint32](value) >> 1))
+    var y = bitcast[DType.float32](0x5F3759DF - (bitcast[DType.uint32](value) >> 1))
     return y * (1.5 - 0.5 * value * y * y)
 
 

--- a/basalt/nn/layers/linear.mojo
+++ b/basalt/nn/layers/linear.mojo
@@ -8,7 +8,7 @@ from basalt.autograd.params import Param
 
 @always_inline("nodebug")
 fn q_sqrt(value: Float32) -> Float32:
-    var y = bitcast[DType.float32](0x5f3759df - (bitcast[DType.uint32](value) >> 1))
+    var y = bitcast[DType.float32](0x5F3759DF - (bitcast[DType.uint32](value) >> 1))
     return y * (1.5 - 0.5 * value * y * y)
 
 

--- a/basalt/nn/model.mojo
+++ b/basalt/nn/model.mojo
@@ -30,7 +30,7 @@ fn calc_n_inference_nodes(g: Graph) -> Optional[Int]:
     The number of inference nodes is that index + 1.
     """
     for i in range(len(g.nodes) - 1, -1, -1):
-        if dv_contains(g.outputs, g.nodes[i].outputs[0]):
+        if dv_contains(g.outputs, g.nodes[i].output):
             return i + 1
     return None
 
@@ -134,7 +134,7 @@ struct Model[
         fn fw_unroll[i: Int]():
             alias op = g.nodes[i].operator
             alias t1 = g.nodes[i].inputs[0]
-            alias out = g.nodes[i].outputs[0]
+            alias out = g.nodes[i].output
             alias attrs = g.nodes[i].attributes
 
             # Save start time for performance metrics
@@ -187,7 +187,7 @@ struct Model[
         fn bw_unroll[i: Int]():
             alias reverse_i = g.nodes.size - i - 1
             alias op = g.nodes[reverse_i].operator
-            alias out = g.nodes[reverse_i].outputs[0]  # or upper_grad symbol
+            alias out = g.nodes[reverse_i].output  # or upper_grad symbol
             alias t1 = g.nodes[reverse_i].inputs[0]
             alias attrs = g.nodes[reverse_i].attributes
 
@@ -296,13 +296,13 @@ struct Model[
                 # Default parameter initialization to zero
                 par = Tensor[dtype](p.shape)
 
-            self.parameters.params.append(par ^, p)
+            self.parameters.params.append(par^, p)
 
         for i in range(len(g.nodes)):
             # Assumption: There is only one output tensor per node
             # Assumption: An input or a param cannot be an output of a node
             self.parameters.params.append(
-                Tensor[dtype](g.nodes[i].outputs[0].shape), g.nodes[i].outputs[0]
+                Tensor[dtype](g.nodes[i].output.shape), g.nodes[i].output
             )
 
     fn allocate_grad_memory(inout self):
@@ -314,7 +314,7 @@ struct Model[
                 self.parameters.grads.append(Tensor[dtype](grad.shape), grad)
 
         for i in range(len(g.nodes)):
-            var out = g.nodes[i].outputs[0]
+            var out = g.nodes[i].output
             if out.trainable:
                 self.parameters.grads.append(Tensor[dtype](out.shape), out)
 

--- a/basalt/utils/perf_utils.mojo
+++ b/basalt/utils/perf_utils.mojo
@@ -180,7 +180,9 @@ struct PerfMetrics:
 
             if print_shape:
                 var shape_str: String = ""
-                shape_str += fit_string[15]("<" + str(value.node.outputs[0].shape) + ">")
+                shape_str += fit_string[15](
+                    "<" + str(value.node.outputs[0].shape) + ">"
+                )
                 shape_str += fit_string[7](" = OP(")
                 shape_str += fit_string[15]("<" + str(value.node.inputs[0].shape) + ">")
                 for j in range(1, len(value.node.inputs)):

--- a/basalt/utils/perf_utils.mojo
+++ b/basalt/utils/perf_utils.mojo
@@ -180,19 +180,14 @@ struct PerfMetrics:
 
             if print_shape:
                 var shape_str: String = ""
-                shape_str += fit_string[15]("<" + str(value.node.output.shape) + ">")
+                shape_str += fit_string[15]("<" + str(value.node.outputs[0].shape) + ">")
                 shape_str += fit_string[7](" = OP(")
-                shape_str += fit_string[15]("<" + str(value.node.input_1.shape) + ">")
-                if value.node.input_2:
+                shape_str += fit_string[15]("<" + str(value.node.inputs[0].shape) + ">")
+                for j in range(1, len(value.node.inputs)):
                     shape_str += ", " + fit_string[15](
-                        "<" + str(value.node.input_2.value().shape) + ">"
-                    )
-                if value.node.input_3:
-                    shape_str += ", " + fit_string[15](
-                        "<" + str(value.node.input_3.value().shape) + ">"
+                        "<" + str(value.node.inputs[j].shape) + ">"
                     )
                 shape_str += ")"
-
                 print_value += shape_str
 
             print(print_value)

--- a/basalt/utils/perf_utils.mojo
+++ b/basalt/utils/perf_utils.mojo
@@ -181,7 +181,7 @@ struct PerfMetrics:
             if print_shape:
                 var shape_str: String = ""
                 shape_str += fit_string[15](
-                    "<" + str(value.node.outputs[0].shape) + ">"
+                    "<" + str(value.node.output.shape) + ">"
                 )
                 shape_str += fit_string[7](" = OP(")
                 shape_str += fit_string[15]("<" + str(value.node.inputs[0].shape) + ">")

--- a/test/test_mlops.mojo
+++ b/test/test_mlops.mojo
@@ -230,16 +230,22 @@ fn test_SQUEEZE() raises:
     # Test with one dim
     expected = Tensor[dtype](1, 2, 1, 3)
     fill(expected, 5.0)
-    test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(4)))](t1, expected)
+    test_unary_op[
+        OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(4)))
+    ](t1, expected)
 
     expected = Tensor[dtype](1, 2, 3, 1)
     fill(expected, 5.0)
-    test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(2)))](t1, expected)
+    test_unary_op[
+        OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(2)))
+    ](t1, expected)
 
     # Test with multiple dims
     expected = Tensor[dtype](1, 2, 3)
     fill(expected, 5.0)
-    test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(2, 4)))](t1, expected)
+    test_unary_op[
+        OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(2, 4)))
+    ](t1, expected)
 
 
 fn test_backward_SQUEEZE() raises:
@@ -265,20 +271,28 @@ fn test_UNSQUEEZE() raises:
 
     var expected = Tensor[dtype](2, 1, 3, 1)
     fill(expected, 5.0)
-    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1, 3)))](t1, expected)
+    test_unary_op[
+        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1, 3)))
+    ](t1, expected)
 
     expected = Tensor[dtype](2, 1, 3)
     fill(expected, 5.0)
 
-    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1)))](t1, expected)
+    test_unary_op[
+        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1)))
+    ](t1, expected)
 
     expected = Tensor[dtype](1, 2, 3)
     fill(expected, 5.0)
-    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-3)))](t1, expected)
+    test_unary_op[
+        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-3)))
+    ](t1, expected)
 
     expected = Tensor[dtype](2, 1, 3, 1)
     fill(expected, 5.0)
-    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-1, -3)))](t1, expected)
+    test_unary_op[
+        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-1, -3)))
+    ](t1, expected)
 
 
 fn test_backward_UNSQUEEZE() raises:

--- a/test/test_mlops_torch.mojo
+++ b/test/test_mlops_torch.mojo
@@ -292,7 +292,9 @@ fn test_SQUEEZE() raises:
 
     alias dims = Attribute("dims", dims_shape)
 
-    expected_and_grad = torch_unary_op(OP.SQUEEZE, t1, ug, attrs_tuple=PythonObject(dims_tuple))
+    expected_and_grad = torch_unary_op(
+        OP.SQUEEZE, t1, ug, attrs_tuple=PythonObject(dims_tuple)
+    )
     test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(dims)](
         t1, expected_and_grad.expected
     )
@@ -313,7 +315,9 @@ fn test_UNSQUEEZE() raises:
     alias dim = Attribute("dims", TensorShape(1))
 
     var expected_and_grad = torch_unary_op(OP.UNSQUEEZE, t1, ug, AttributeVector(dim))
-    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(dim)](t1, expected_and_grad.expected)
+    test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(dim)](
+        t1, expected_and_grad.expected
+    )
     test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape, AttributeVector(dim)](
         t1, ug, expected_and_grad.grad_1
     )
@@ -327,13 +331,16 @@ fn test_UNSQUEEZE() raises:
 
     alias dims = Attribute("dims", dims_shape)
 
-    expected_and_grad = torch_unary_op(OP.UNSQUEEZE, t1, ug, attrs_tuple=PythonObject(dims_tuple))
+    expected_and_grad = torch_unary_op(
+        OP.UNSQUEEZE, t1, ug, attrs_tuple=PythonObject(dims_tuple)
+    )
     test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(dims)](
         t1, expected_and_grad.expected
     )
     test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape_2, AttributeVector(dims)](
         t1, ug, expected_and_grad.grad_1
     )
+
 
 fn main():
     print("Running mlops (compare with torch) tests")

--- a/test/test_mlops_torch.mojo
+++ b/test/test_mlops_torch.mojo
@@ -13,7 +13,14 @@ from basalt.autograd.attributes import Attribute, AttributeVector
 from basalt.utils.tensorutils import fill
 from basalt.autograd.ops.ops import backward_op
 
-from test_utils_extras import to_numpy, to_tensor, test_unary_op, test_unary_op_backward
+from test_utils_extras import (
+    to_numpy,
+    to_tensor,
+    test_unary_op,
+    test_binary_op,
+    test_unary_op_backward,
+    test_binary_op_backward
+)
 
 alias dtype = DType.float32
 alias nelts: Int = simdwidthof[dtype]()
@@ -301,20 +308,84 @@ fn test_UNSQUEEZE() raises:
     )
 
 
-# fn test_CONCAT2() raises:
-#     alias t1_shape = TensorShape(20, 28)
-#     alias t2_shape = TensorShape(20, 28)
-#     var t1 = Tensor[dtype](t1_shape)
-#     var t2 = Tensor[dtype](t2_shape)
-#     rand(t1.data(), t1.num_elements())
-#     rand(t2.data(), t2.num_elements())
+@value
+struct torch_output_cat:
+    var expected: Tensor[dtype]
+    var grad_1: Tensor[dtype]
+    var grad_2: Tensor[dtype]
 
-#     # default: dim = 0
-#     alias ug_shape = TensorShape(40, 28) 
-#     var ug = Tensor[dtype](ug_shape)
-#     rand(ug.data(), ug.num_elements())
 
-#     var expected_and_grad = torch_op(OP.CONCAT2, ug, t1, t2)
+fn torch_cat_op(
+    op: OP, input_1: Tensor, input_2: Tensor, upper_grad: Tensor, dim: Int
+) -> torch_output_cat:
+    try:
+        var py = Python.import_module("builtins")
+        var torch = Python.import_module("torch")
+        var np = Python.import_module("numpy")
+
+        var input_1 = torch.from_numpy(to_numpy(input_1)).requires_grad_(True)
+        var input_2 = torch.from_numpy(to_numpy(input_2)).requires_grad_(True)
+
+        var expected: PythonObject
+
+        if op == OP.CONCAT2:
+            var tensors = py.list()
+            tensors.append(input_1)
+            tensors.append(input_2)
+            expected = torch.cat(tensors, dim=dim)
+        else:
+            print("Error: op not supported, ", op)
+            expected = input_1
+
+        # uppergrad & backwards
+        var upper_grad = torch.from_numpy(to_numpy(upper_grad))
+        _ = expected.backward(upper_grad)
+
+        return torch_output_cat(
+            to_tensor(expected.detach().numpy()),
+            to_tensor(input_1.grad.numpy()),
+            to_tensor(input_2.grad.numpy()),
+        )
+
+    except e:
+        print("Error importing torch: ", e)
+        var d = Tensor[dtype](1)
+        return torch_output_cat(d, d, d)
+
+
+fn test_CONCAT2() raises:
+    alias t1_shape = TensorShape(20, 28)
+    alias t2_shape = TensorShape(20, 28)
+    var t1 = Tensor[dtype](t1_shape)
+    var t2 = Tensor[dtype](t2_shape)
+    rand(t1.data(), t1.num_elements())
+    rand(t2.data(), t2.num_elements())
+
+    # default: dim = 0
+    alias ug_shape = TensorShape(40, 28) 
+    var ug = Tensor[dtype](ug_shape)
+    rand(ug.data(), ug.num_elements())
+
+    var expected_and_grad = torch_cat_op(OP.CONCAT2, t1, t2, ug, dim=0)
+    test_binary_op[OP.CONCAT2, t1_shape, t2_shape](
+        t1, t2, expected_and_grad.expected
+    )
+    test_binary_op_backward[OP.CONCAT2, t1_shape, t2_shape, ug_shape](
+        t1, t2, ug, expected_and_grad.grad_1, expected_and_grad.grad_2
+    )
+
+    # dim = 1
+    alias ug_shape_1 = TensorShape(20, 56)
+    ug = Tensor[dtype](ug_shape_1)
+    rand(ug.data(), ug.num_elements())
+
+    expected_and_grad = torch_cat_op(OP.CONCAT2, t1, t2, ug, dim=1)
+    test_binary_op[OP.CONCAT2, t1_shape, t2_shape, AttributeVector(Attribute("dim", 1))](
+        t1, t2, expected_and_grad.expected
+    )
+    test_binary_op_backward[OP.CONCAT2, t1_shape, t2_shape, ug_shape_1, AttributeVector(Attribute("dim", 1))](
+        t1, t2, ug, expected_and_grad.grad_1, expected_and_grad.grad_2
+    )
 
 
 fn main():
@@ -326,6 +397,7 @@ fn main():
         test_CLIP()
         test_SQUEEZE()
         test_UNSQUEEZE()
+        test_CONCAT2()
     except e:
         print("[ERROR] Error in mlops (compare with torch)")
         print(e)

--- a/test/test_ops.mojo
+++ b/test/test_ops.mojo
@@ -9,73 +9,14 @@ from basalt import Graph, Symbol, OP
 from basalt.autograd.attributes import Attribute, AttributeVector
 from basalt.utils.tensorutils import fill
 
+from test_utils_extras import test_unary_op, test_binary_op, test_ternary_op
+
 alias dtype = DType.float32
 alias nelts: Int = simdwidthof[dtype]()
 
 
-fn test_ternary_op[
-    op: OP, t1_shape: TensorShape, t2_shape: TensorShape, t3_shape: TensorShape
-](
-    t1: Tensor[dtype], t2: Tensor[dtype], t3: Tensor[dtype], expected: Tensor[dtype]
-) raises:
-    fn create_graph() -> Graph:
-        var g = Graph()
-        var t1 = g.input(t1_shape)
-        var t2 = g.input(t2_shape)
-        var t3 = g.input(t3_shape)
-
-        var res = g.op(op, t1, t2, t3)
-        g.out(res)
-
-        return g ^
-
-    alias graph = create_graph()
-    assert_equal(len(graph.nodes), 1)
-
-    var model = nn.Model[graph](inference_only=True)
-    var res = model.inference(t1, t2, t3)[0]
-    assert_tensors_equal(res, expected)
-
-
-fn test_FMA() raises:
-    alias t1_shape = TensorShape(2, 3)
-    alias t2_shape = TensorShape(2, 3)
-    alias t3_shape = TensorShape(2, 3)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-    var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
-    var t3: Tensor[dtype] = Tensor[dtype](t3_shape)
-    fill(t1, 1.0)
-    fill(t2, 2.0)
-    fill(t3, 3.0)
-
-    var expected = Tensor[dtype](2, 3)
-    fill(expected, 1.0 * 2.0 + 3.0)
-
-    test_ternary_op[OP.FMA, t1_shape, t2_shape, t3_shape](t1, t2, t3, expected)
-
 
 # ------ Test Binary Ops ------
-fn test_binary_op[
-    op: OP, t1_shape: TensorShape, t2_shape: TensorShape
-](t1: Tensor[dtype], t2: Tensor[dtype], expected: Tensor[dtype]) raises:
-    fn create_graph() -> Graph:
-        var g = Graph()
-        var t1 = g.input(t1_shape)
-        var t2 = g.input(t2_shape)
-
-        var res = g.op(op, t1, t2)
-        g.out(res)
-
-        return g ^
-
-    alias graph = create_graph()
-    assert_equal(len(graph.nodes), 1)
-
-    var model = nn.Model[graph](inference_only=True)
-    var res = model.inference(t1, t2)[0]
-    assert_tensors_equal(res, expected)
-
-
 fn test_ADD() raises:
     alias t1_shape = TensorShape(2, 3)
     alias t2_shape = TensorShape(2, 3)
@@ -147,27 +88,6 @@ fn test_DOT() raises:
 
 
 # ------ Test Unary Ops ------
-fn test_unary_op[
-    op: OP, t1_shape: TensorShape
-](t1: Tensor[dtype], expected: Tensor[dtype]) raises:
-    fn create_graph() -> Graph:
-        var g = Graph()
-        var t1 = g.input(t1_shape)
-
-        var res = g.op(op, t1)
-        g.out(res)
-
-        return g ^
-
-    alias graph = create_graph()
-    assert_equal(len(graph.nodes), 1)
-
-    var model = nn.Model[graph](inference_only=True)
-    var res = model.inference(t1)[0]
-
-    assert_tensors_equal(res, expected)
-
-
 fn test_EXP() raises:
     alias t1_shape = TensorShape(2, 3)
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
@@ -469,6 +389,23 @@ fn test_RESHAPE() raises:
     var res = model.inference(t)[0]
 
     assert_tensors_equal(res, expected)
+
+
+fn test_FMA() raises:
+    alias t1_shape = TensorShape(2, 3)
+    alias t2_shape = TensorShape(2, 3)
+    alias t3_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
+    var t3: Tensor[dtype] = Tensor[dtype](t3_shape)
+    fill(t1, 1.0)
+    fill(t2, 2.0)
+    fill(t3, 3.0)
+
+    var expected = Tensor[dtype](2, 3)
+    fill(expected, 1.0 * 2.0 + 3.0)
+
+    test_ternary_op[OP.FMA, t1_shape, t2_shape, t3_shape](t1, t2, t3, expected)
 
 
 fn main():

--- a/test/test_utils_extras.mojo
+++ b/test/test_utils_extras.mojo
@@ -1,5 +1,13 @@
 from python.python import Python
+from collections.optional import OptionalReg
+from testing import assert_equal
+from test_tensorutils import assert_tensors_equal
+
+import basalt.nn as nn
 from basalt import Tensor, TensorShape
+from basalt import Graph, Symbol, OP
+from basalt.autograd.ops.ops import backward_op
+from basalt.autograd.attributes import AttributeVector, Attribute
 
 
 alias dtype = DType.float32
@@ -42,3 +50,147 @@ fn to_tensor(np_array: PythonObject) raises -> Tensor[dtype]:
         tensor[i] = np_array_temp[i].to_float64().cast[dtype]()
 
     return tensor
+
+
+# ------- Test forward ops -------
+fn test_unary_op[
+    op: OP, t1_shape: TensorShape, attrs: OptionalReg[AttributeVector] = None
+](t1: Tensor[dtype], expected: Tensor[dtype]) raises:
+    fn create_graph() -> Graph:
+        var g = Graph()
+        var t1 = g.input(t1_shape)
+
+        var res: Symbol
+        if attrs:
+            res = g.op(op, t1, attributes=attrs.value())
+        else:
+            res = g.op(op, t1)
+        g.out(res)
+
+        return g ^
+
+    alias graph = create_graph()
+    assert_equal(len(graph.nodes), 1)
+
+    var model = nn.Model[graph](inference_only=True)
+    var res = model.inference(t1)[0]
+
+    assert_tensors_equal(res, expected, "almost")
+
+
+fn test_binary_op[
+    op: OP, t1_shape: TensorShape, t2_shape: TensorShape, attrs: OptionalReg[AttributeVector] = None
+](t1: Tensor[dtype], t2: Tensor[dtype], expected: Tensor[dtype]) raises:
+    fn create_graph() -> Graph:
+        var g = Graph()
+        var t1 = g.input(t1_shape)
+        var t2 = g.input(t2_shape)
+
+        var res: Symbol
+        if attrs:
+            res = g.op(op, t1, t2, attributes=attrs.value())
+        else:
+            res = g.op(op, t1, t2)
+        g.out(res)
+
+        return g ^
+
+    alias graph = create_graph()
+    assert_equal(len(graph.nodes), 1)
+
+    var model = nn.Model[graph](inference_only=True)
+    var res = model.inference(t1, t2)[0]
+
+    assert_tensors_equal(res, expected, "almost")
+
+
+fn test_ternary_op[
+    op: OP, t1_shape: TensorShape, t2_shape: TensorShape, t3_shape: TensorShape
+](
+    t1: Tensor[dtype], t2: Tensor[dtype], t3: Tensor[dtype], expected: Tensor[dtype]
+) raises:
+    @parameter
+    fn create_graph() -> Graph:
+        var g = Graph()
+        var t1 = g.input(t1_shape)
+        var t2 = g.input(t2_shape)
+        var t3 = g.input(t3_shape)
+
+        var res = g.op(op, t1, t2, t3)
+        g.out(res)
+
+        return g ^
+
+    alias graph = create_graph()
+    assert_equal(len(graph.nodes), 1)
+
+    var model = nn.Model[graph](inference_only=True)
+    var res = model.inference(t1, t2, t3)[0]
+
+    assert_tensors_equal(res, expected, "almost")
+
+
+# ------- Test backward ops -------
+fn test_unary_op_backward[
+    op: OP, t1_shape: TensorShape, ug_shape: TensorShape, attrs: AttributeVector = AttributeVector()
+](t1: Tensor[dtype], ug: Tensor[dtype], grad_1_expected: Tensor[dtype],) raises:
+    var grad_1 = Tensor[dtype](t1_shape)
+    backward_op[0, op, ug_shape, t1_shape, attrs](ug, t1, grad_1)
+    assert_tensors_equal(grad_1, grad_1_expected, "almost")
+
+
+fn test_binary_op_backward[
+    op: OP, t1_shape: TensorShape, t2_shape: TensorShape, ug_shape: TensorShape, attrs: AttributeVector = AttributeVector()
+](
+    t1: Tensor[dtype],
+    t2: Tensor[dtype],
+    ug: Tensor[dtype],
+    grad_1_expected: Tensor[dtype],
+    grad_2_expected: Tensor[dtype],
+) raises:
+    var grad_1 = Tensor[dtype](t1_shape)
+    backward_op[0, op, ug_shape, t1_shape, t2_shape, attrs](
+        ug, t1, t2, grad_1
+    )
+    assert_tensors_equal(grad_1, grad_1_expected, "almost")
+
+    var grad_2 = Tensor[dtype](t2_shape)
+    backward_op[1, op, ug_shape, t1_shape, t2_shape, attrs](
+        ug, t1, t2, grad_2
+    )
+    assert_tensors_equal(grad_2, grad_2_expected, "almost")
+
+
+fn test_ternary_op_backward[
+    op: OP,
+    t1_shape: TensorShape,
+    t2_shape: TensorShape,
+    t3_shape: TensorShape,
+    ug_shape: TensorShape,
+    attrs: AttributeVector = AttributeVector()
+](
+    t1: Tensor[dtype],
+    t2: Tensor[dtype],
+    t3: Tensor[dtype],
+    ug: Tensor[dtype],
+    grad_1_expected: Tensor[dtype],
+    grad_2_expected: Tensor[dtype],
+    grad_3_expected: Tensor[dtype],
+) raises:
+    var grad_1 = Tensor[dtype](t1_shape)
+    backward_op[0, op, ug_shape, t1_shape, t2_shape, t3_shape, attrs](
+        ug, t1, t2, t3, grad_1
+    )
+    assert_tensors_equal(grad_1, grad_1_expected, "almost")
+
+    var grad_2 = Tensor[dtype](t2_shape)
+    backward_op[1, op, ug_shape, t1_shape, t2_shape, t3_shape, attrs](
+        ug, t1, t2, t3, grad_2
+    )
+    assert_tensors_equal(grad_2, grad_2_expected, "almost")
+
+    var grad_3 = Tensor[dtype](t3_shape)
+    backward_op[2, op, ug_shape, t1_shape, t2_shape, t3_shape, attrs](
+        ug, t1, t2, t3, grad_3
+    )
+    assert_tensors_equal(grad_3, grad_3_expected, "almost")


### PR DESCRIPTION
Concatenating 2 operand tensor along a specified dimension
- CONCAT2 forward op
- CONCAT2 backward op
- unittests for both

**remark 1**
We need to fix the number of operands in the core operator here as a requirement to statically know the shapes. The API could expose a more general `concat()` function taking in a list of symbols of arbitrary length. And that operator can use a series of core CONCAT2 ops, or implement more CONCATx 

**remark 2**
I was originally planning on implementing split here as well, but this operator is going to be more complex then originally though. So focussing on concat only. The graph doesn't have issues with specifying Nodes/OPs that have multiple outputs. But the flow in model.execute is going to be WAY more complicated if we want to support core operators with multiple outputs. My current thought on SPLIT is to implement SLICE as core operator and create `g.split()` as a combination of slices. That should be equivalent as slice fw/bw & accumulate_grad should take care of everything. Partially proposing this as well as (afaik) split and slice are the only ops with multiple output tensors in the graph. In the case that is true, it's probably not worth complicating model.execute that much for only these cases. Thoughts are more then welcome on this ... 
