### PR TITLE
Changed SIMD[Type, 1] to Scalar[Type]

### DIFF
--- a/basalt/autograd/graph.mojo
+++ b/basalt/autograd/graph.mojo
@@ -48,7 +48,7 @@ struct Graph:
         self.symbol_count += 1
         return param_id
 
-    fn scalar(inout self, value: SIMD[dtype, 1]) -> Symbol:
+    fn scalar(inout self, value: Scalar[dtype]) -> Symbol:
         var scal = Param(value)
         var scalar_id = Symbol(
             self.symbol_count, dtype, TensorShape(1), trainable=False
@@ -57,7 +57,7 @@ struct Graph:
         self.symbol_count += 1
         return scalar_id
 
-    fn constant(inout self, shape: TensorShape, data: List[SIMD[dtype, 1]]) -> Symbol:
+    fn constant(inout self, shape: TensorShape, data: List[Scalar[dtype]]) -> Symbol:
         var cst = Param(data)
         var constant_id = Symbol(self.symbol_count, dtype, shape, trainable=False)
         self.params.put(constant_id, cst)

--- a/basalt/autograd/ops/basics.mojo
+++ b/basalt/autograd/ops/basics.mojo
@@ -152,7 +152,7 @@ struct DIV:
 
             @parameter
             if is_scalar:
-                var factor: SIMD[dtype, 1] = -1.0 / (t2[0] ** 2)
+                var factor: Scalar[dtype] = -1.0 / (t2[0] ** 2)
 
                 @parameter
                 fn vec_div_bw_scalar[nelts: Int](i: Int):
@@ -440,7 +440,7 @@ struct MEAN:
         # d(mean(t)) / dt = 1 / t.num_elements()
         var res_grad = Tensor[dtype](t_shape)
 
-        var grad: SIMD[dtype, 1] = 1.0 / t_shape.num_elements()
+        var grad: Scalar[dtype] = 1.0 / t_shape.num_elements()
 
         grad = (
             grad * ug[0]
@@ -462,7 +462,7 @@ struct MEAN:
         # d(mean(t)) / dt = 1 / t.dim(axis)
         var res_grad = Tensor[dtype](t_shape)
 
-        var grad: SIMD[dtype, 1] = 1.0 / t_shape[axis]
+        var grad: Scalar[dtype] = 1.0 / t_shape[axis]
 
         fill(res_grad, grad)
 
@@ -528,7 +528,7 @@ struct MAX:
 
         # ug_shape size is 1
         var max_res = tmax(t)
-        var sum_eq: SIMD[dtype, 1] = 0
+        var sum_eq: Scalar[dtype] = 0
         for i in range(t.num_elements()):
             if t[i] == max_res:
                 sum_eq += 1
@@ -562,7 +562,7 @@ struct MAX:
                 strides[axis] * t.dim(axis)
             )
 
-            var count_1s: SIMD[dtype, 1] = 0
+            var count_1s: Scalar[dtype] = 0
             # Count the number of values equal to max_res
             for j in range(t.dim(axis)):
                 var index = index_base + j * strides[axis]

--- a/basalt/autograd/ops/conv.mojo
+++ b/basalt/autograd/ops/conv.mojo
@@ -311,7 +311,7 @@ struct CONV2D:
 
                     # TODO: Cant vectorize since you are going different directions across input and upper grad
                     # But theoretically could transpose or split somehow
-                    var result: SIMD[dtype, 1] = 0
+                    var result: Scalar[dtype] = 0
                     for batch in range(input_shape_0):
                         for ux in range(ug_shape_2):
                             for uy in range(ug_shape_3):
@@ -351,7 +351,7 @@ struct CONV2D:
             @parameter
             fn bias_grad(out_ch: Int):
                 var channel_offset = out_ch * ug_strides_1
-                var sum: SIMD[dtype, 1] = 0
+                var sum: Scalar[dtype] = 0
                 for batch in range(ug_shape_0):
                     var batch_offset = batch * ug_strides_0 + channel_offset
 

--- a/basalt/autograd/ops/pool.mojo
+++ b/basalt/autograd/ops/pool.mojo
@@ -48,7 +48,7 @@ struct MAXPOOL2D:
             for in_ch in range(input_shape[1]):
                 for x in range(output_shape[2]):
                     for y in range(output_shape[3]):
-                        var max_val: SIMD[dtype, 1] = neginf[dtype]()
+                        var max_val: Scalar[dtype] = neginf[dtype]()
                         var ix_base = x * stride[0] - padding[0]
                         var iy_base = y * stride[1] - padding[1]
                         for kx in range(kernel_size[0]):
@@ -107,7 +107,7 @@ struct MAXPOOL2D:
             for in_ch in range(input_shape[1]):
                 for x in range(ug_shape[2]):
                     for y in range(ug_shape[3]):
-                        var max_val: SIMD[dtype, 1] = neginf[dtype]()
+                        var max_val: Scalar[dtype] = neginf[dtype]()
                         var max_idx: Int = -1
                         var ix_base = x * stride[0] - padding[0]
                         var iy_base = y * stride[1] - padding[1]

--- a/basalt/autograd/params.mojo
+++ b/basalt/autograd/params.mojo
@@ -8,36 +8,36 @@ from .attributes import Attribute
 
 @value
 struct Param(CollectionElement, Stringable):
-    var data: Optional[List[SIMD[dtype, 1]]]
+    var data: Optional[List[Scalar[dtype]]]
     var initializer: Optional[Attribute]
 
     fn __init__(inout self):
         self.data = None
         self.initializer = None
 
-    fn __init__(inout self, data: List[SIMD[dtype, 1]]):
+    fn __init__(inout self, data: List[Scalar[dtype]]):
         self.data = data
         self.initializer = None
 
-    fn __init__(inout self, a: SIMD[dtype, 1]):
-        var data = List[SIMD[dtype, 1]]()
+    fn __init__(inout self, a: Scalar[dtype]):
+        var data = List[Scalar[dtype]]()
         data.append(a)
         self.data = data
         self.initializer = None
 
-    fn __init__(inout self, initializer: String, *args: SIMD[dtype, 1]):
+    fn __init__(inout self, initializer: String, *args: Scalar[dtype]):
         # Supported initializers:
         #   "random_uniform", lower_bound, upper_bound
         #   "random_normal", mean, std
         #   #TODO: "kaiming_uniform", mode, nonlinearity
         #   #TODO: "kaiming_normal", mode, nonlinearity
         self.initializer = Attribute("initializer", initializer)
-        var data = List[SIMD[dtype, 1]]()
+        var data = List[Scalar[dtype]]()
         for arg in args:
             data.append(arg)
         self.data = data
 
-    fn __getitem__(self, i: Int) -> Optional[SIMD[dtype, 1]]:
+    fn __getitem__(self, i: Int) -> Optional[Scalar[dtype]]:
         if self.data:
             return self.data.value()[i]
         else:

--- a/basalt/nn/initializers.mojo
+++ b/basalt/nn/initializers.mojo
@@ -6,7 +6,7 @@ from basalt.utils.rand_utils import rand_normal, rand_uniform
 
 
 fn initialize_tensor(
-    shape: TensorShape, type: String, data: List[SIMD[dtype, 1]]
+    shape: TensorShape, type: String, data: List[Scalar[dtype]]
 ) -> Tensor[dtype]:
     if type == "random_uniform":
         var low = data[0]
@@ -35,7 +35,7 @@ fn initialize_tensor(
         return Tensor[dtype]()
 
 
-fn calculate_fan(shape: TensorShape, mode: String) -> SIMD[dtype, 1]:
+fn calculate_fan(shape: TensorShape, mode: String) -> Scalar[dtype]:
     """
     Calculate the fan-in and fan-out of any tensor.
     """

--- a/basalt/nn/optim.mojo
+++ b/basalt/nn/optim.mojo
@@ -28,10 +28,10 @@ struct Adam[
 ]:
     var parameters: Reference[Parameters, mutability, lifetime]
 
-    var lr: SIMD[dtype, 1]
-    var beta1: SIMD[dtype, 1]
-    var beta2: SIMD[dtype, 1]
-    var epsilon: SIMD[dtype, 1]
+    var lr: Scalar[dtype]
+    var beta1: Scalar[dtype]
+    var beta2: Scalar[dtype]
+    var epsilon: Scalar[dtype]
     var iter: Int
 
     var rms_grads: Collection
@@ -40,10 +40,10 @@ struct Adam[
     fn __init__(
         inout self,
         parameters: Reference[Parameters, mutability, lifetime],
-        lr: SIMD[dtype, 1] = 0.001,
-        beta1: SIMD[dtype, 1] = 0.9,
-        beta2: SIMD[dtype, 1] = 0.999,
-        epsilon: SIMD[dtype, 1] = 1e-8,
+        lr: Scalar[dtype] = 0.001,
+        beta1: Scalar[dtype] = 0.9,
+        beta2: Scalar[dtype] = 0.999,
+        epsilon: Scalar[dtype] = 1e-8,
     ):
         self.parameters = parameters
 

--- a/basalt/nn/tensor.mojo
+++ b/basalt/nn/tensor.mojo
@@ -139,11 +139,11 @@ struct Tensor[dtype: DType](Stringable, Movable, CollectionElement):
         self._shape = other._shape
 
     @always_inline("nodebug")
-    fn __getitem__(self, index: Int) -> SIMD[dtype, 1]:
+    fn __getitem__(self, index: Int) -> Scalar[dtype]:
         return self._data[index]
 
     @always_inline("nodebug")
-    fn __setitem__(self, index: Int, value: SIMD[dtype, 1]):
+    fn __setitem__(self, index: Int, value: Scalar[dtype]):
         self._data[index] = value
 
     @always_inline("nodebug")

--- a/basalt/utils/datasets.mojo
+++ b/basalt/utils/datasets.mojo
@@ -131,21 +131,21 @@ fn find_nth(s: String, delimiter: String, n: Int) -> Int:
     return -1
 
 
-fn cast_string[dtype: DType](s: String) raises -> SIMD[dtype, 1]:
+fn cast_string[dtype: DType](s: String) raises -> Scalar[dtype]:
     """
     Cast a string with decimal to a SIMD vector of dtype.
     """
 
     var idx = find_first(s, delimiter=".")
-    var x: SIMD[dtype, 1] = -1
+    var x: Scalar[dtype] = -1
 
     if idx == -1:
         # No decimal point
         x = atol(s)
         return x
     else:
-        var c_int: SIMD[dtype, 1]
-        var c_frac: SIMD[dtype, 1]
+        var c_int: Scalar[dtype]
+        var c_frac: Scalar[dtype]
         c_int = atol(s[:idx])
         c_frac = atol(s[idx + 1 :])
         x = c_int + c_frac / (10 ** len(s[idx + 1 :]))

--- a/basalt/utils/rand_utils.mojo
+++ b/basalt/utils/rand_utils.mojo
@@ -6,7 +6,7 @@ from algorithm import vectorize
 @always_inline
 fn rand_uniform[
     dtype: DType
-](inout res: Tensor[dtype], low: SIMD[dtype, 1], high: SIMD[dtype, 1]):
+](inout res: Tensor[dtype], low: Scalar[dtype], high: Scalar[dtype]):
     rand[dtype](
         res.data(), res.num_elements()
     )  # Uniform initialize the tensor between 0 and 1

--- a/basalt/utils/tensorutils.mojo
+++ b/basalt/utils/tensorutils.mojo
@@ -9,7 +9,7 @@ from basalt.nn.tensor import MAX_RANK
 
 
 @always_inline
-fn fill[dtype: DType](inout t: Tensor[dtype], val: SIMD[dtype, 1]):
+fn fill[dtype: DType](inout t: Tensor[dtype], val: Scalar[dtype]):
     @parameter
     fn fill_vec[nelts: Int](idx: Int):
         t.store[nelts](idx, t.load[nelts](idx).splat(val))
@@ -349,7 +349,7 @@ fn elwise_op[
     func: fn[dtype: DType, nelts: Int] (
         x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]
     ) -> SIMD[dtype, nelts],
-](inout res: Tensor[dtype], t1: Tensor[dtype], a: SIMD[dtype, 1]):
+](inout res: Tensor[dtype], t1: Tensor[dtype], a: Scalar[dtype]):
     """Element-wise operation on a tensor and a scalar."""
 
     @parameter
@@ -364,7 +364,7 @@ fn elwise_op[
     func: fn[dtype: DType, nelts: Int] (
         x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]
     ) -> SIMD[dtype, nelts],
-](inout res: Tensor[dtype], a: SIMD[dtype, 1], t1: Tensor[dtype]):
+](inout res: Tensor[dtype], a: Scalar[dtype], t1: Tensor[dtype]):
     """Element-wise operation on a tensor and a scalar."""
 
     @parameter
@@ -485,7 +485,7 @@ fn reduce[
     reduce_op: fn[type: DType, simd_width: Int] (x: SIMD[type, simd_width]) -> SIMD[
         type, 1
     ],
-](t: Tensor[dtype], starting_value: SIMD[dtype, nelts]) -> SIMD[dtype, 1]:
+](t: Tensor[dtype], starting_value: SIMD[dtype, nelts]) -> Scalar[dtype]:
     var m: SIMD[dtype, nelts] = starting_value
 
     @parameter
@@ -560,25 +560,25 @@ fn reduce[
 @always_inline
 fn _reduce_sum[
     type: DType, simd_width: Int
-](x: SIMD[type, simd_width]) -> SIMD[type, 1]:
+](x: SIMD[type, simd_width]) -> Scalar[type]:
     return x.reduce_add()
 
 
 @always_inline
-fn tsum(t: Tensor[dtype]) -> SIMD[dtype, 1]:
+fn tsum(t: Tensor[dtype]) -> Scalar[dtype]:
     var starting_value = 0
     return reduce[add, _reduce_sum](t, starting_value)
 
 
 @always_inline
-fn tmean(t: Tensor[dtype]) -> SIMD[dtype, 1]:
+fn tmean(t: Tensor[dtype]) -> Scalar[dtype]:
     return tsum(t) / t.num_elements()
 
 
 @always_inline
-fn tstd(t: Tensor[dtype]) -> SIMD[dtype, 1]:
-    var mu: SIMD[dtype, 1] = tmean(t)
-    var variance: SIMD[dtype, 1] = 0
+fn tstd(t: Tensor[dtype]) -> Scalar[dtype]:
+    var mu: Scalar[dtype] = tmean(t)
+    var variance: Scalar[dtype] = 0
 
     @parameter
     fn vecvar[nelts: Int](idx: Int):
@@ -598,7 +598,7 @@ fn tsum(inout res: Tensor[dtype], t: Tensor[dtype], axis: Int):
 
 @always_inline
 fn tmean(inout res: Tensor[dtype], t: Tensor[dtype], axis: Int):
-    var num_elements_axis: SIMD[dtype, 1] = t.dim(axis)
+    var num_elements_axis: Scalar[dtype] = t.dim(axis)
     tsum(res, t, axis)
     elwise_op[div](res, res, num_elements_axis)
 
@@ -608,7 +608,7 @@ fn tstd(inout res: Tensor[dtype], t: Tensor[dtype], axis: Int):
     var mu = Tensor[dtype](get_reduce_shape(t.shape(), axis))
     tmean(mu, t, axis)
 
-    var num_elements_axis: SIMD[dtype, 1] = t.dim(axis)
+    var num_elements_axis: Scalar[dtype] = t.dim(axis)
     var strides = t.strides()
     var strides_mu = mu.strides()
 
@@ -654,12 +654,12 @@ fn tstd(inout res: Tensor[dtype], t: Tensor[dtype], axis: Int):
 @always_inline
 fn _reduce_max[
     type: DType, simd_width: Int
-](x: SIMD[type, simd_width]) -> SIMD[type, 1]:
+](x: SIMD[type, simd_width]) -> Scalar[type]:
     return x.reduce_max()
 
 
 @always_inline
-fn tmax(t: Tensor[dtype]) -> SIMD[dtype, 1]:
+fn tmax(t: Tensor[dtype]) -> Scalar[dtype]:
     var starting_value = math.limit.min_finite[dtype]()
     return reduce[max, _reduce_max](t, starting_value)
 

--- a/test/test_loss.mojo
+++ b/test/test_loss.mojo
@@ -73,7 +73,7 @@ fn test_MSE_imperfect() raises:
 
     var loss = model.inference(y_pred, y_true)[0]
 
-    var expected_loss: SIMD[dtype, 1] = 0.0
+    var expected_loss: Scalar[dtype] = 0.0
 
     for i in range(10):
         expected_loss += (y_pred[i] - y_true[i]) ** 2

--- a/test/test_models_mnist.mojo
+++ b/test/test_models_mnist.mojo
@@ -12,12 +12,12 @@ from test_conv import to_numpy, to_tensor
 
 fn create_CNN(
     batch_size: Int,
-    conv1_weights: List[SIMD[dtype, 1]],
-    conv1_bias: List[SIMD[dtype, 1]],
-    conv2_weights: List[SIMD[dtype, 1]],
-    conv2_bias: List[SIMD[dtype, 1]],
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
+    conv1_weights: List[Scalar[dtype]],
+    conv1_bias: List[Scalar[dtype]],
+    conv2_weights: List[Scalar[dtype]],
+    conv2_bias: List[Scalar[dtype]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
 ) -> Graph:
     var g = Graph()
     var x = g.input(TensorShape(batch_size, 1, 28, 28))
@@ -89,18 +89,18 @@ fn create_CNN(
 
 fn run_mojo[
     batch_size: Int,
-    conv1_weights: List[SIMD[dtype, 1]],
-    conv1_bias: List[SIMD[dtype, 1]],
-    conv2_weights: List[SIMD[dtype, 1]],
-    conv2_bias: List[SIMD[dtype, 1]],
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
+    conv1_weights: List[Scalar[dtype]],
+    conv1_bias: List[Scalar[dtype]],
+    conv2_weights: List[Scalar[dtype]],
+    conv2_bias: List[Scalar[dtype]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
 ](
     epochs: Int,
     learning_rate: Float64,
     inputs: Tensor[dtype],
     labels: Tensor[dtype],
-) -> List[SIMD[dtype, 1]]:
+) -> List[Scalar[dtype]]:
     alias graph = create_CNN(
         batch_size,
         conv1_weights,
@@ -114,7 +114,7 @@ fn run_mojo[
     var model = nn.Model[graph]()
     var optim = nn.optim.Adam[graph](Reference(model.parameters), lr=learning_rate)
 
-    var losses = List[SIMD[dtype, 1]]()
+    var losses = List[Scalar[dtype]]()
 
     for i in range(epochs):
         var loss = model.forward(inputs, labels)
@@ -140,8 +140,8 @@ fn run_torch(
     owned conv2_bias: Tensor,
     owned linear1_weights: Tensor,
     owned linear1_bias: Tensor,
-) -> List[SIMD[dtype, 1]]:
-    var out: List[SIMD[dtype, 1]] = List[SIMD[dtype, 1]]()
+) -> List[Scalar[dtype]]:
+    var out: List[Scalar[dtype]] = List[Scalar[dtype]]()
 
     try:
         var torch = Python.import_module("torch")
@@ -197,17 +197,17 @@ fn run_torch(
         return out
 
 
-fn create_weights(num_elements: Int, zero: Bool) -> List[SIMD[dtype, 1]]:
-    var weights = List[SIMD[dtype, 1]](capacity=num_elements)
+fn create_weights(num_elements: Int, zero: Bool) -> List[Scalar[dtype]]:
+    var weights = List[Scalar[dtype]](capacity=num_elements)
     for i in range(num_elements):
         if zero:
-            weights.append(SIMD[dtype, 1](0.0))
+            weights.append(Scalar[dtype](0.0))
         else:
-            weights.append(SIMD[dtype, 1](0.02))
+            weights.append(Scalar[dtype](0.02))
     return weights ^
 
 
-fn dv_to_tensor(dv: List[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
+fn dv_to_tensor(dv: List[Scalar[dtype]], shape: TensorShape) -> Tensor[dtype]:
     var t = Tensor[dtype](shape)
     if t.num_elements() != len(dv):
         print("[WARNING] tensor and dv not the shame shape")

--- a/test/test_models_regression.mojo
+++ b/test/test_models_regression.mojo
@@ -14,8 +14,8 @@ from basalt.utils.rand_utils import MersenneTwister
 fn create_linear_regression(
     batch_size: Int,
     n_outputs: Int,
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
 ) -> Graph:
     var g = Graph()
     var x = g.input(TensorShape(batch_size, 13))
@@ -38,14 +38,14 @@ fn create_linear_regression(
 fn run_mojo[
     batch_size: Int,
     n_outputs: Int,
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
 ](
     epochs: Int,
     learning_rate: Float64,
     inputs: Tensor[dtype],
     labels: Tensor[dtype],
-) -> List[SIMD[dtype, 1]]:
+) -> List[Scalar[dtype]]:
     alias graph = create_linear_regression(
         batch_size,
         n_outputs,
@@ -56,7 +56,7 @@ fn run_mojo[
     var model = nn.Model[graph]()
     var optim = nn.optim.Adam[graph](Reference(model.parameters), lr=learning_rate)
 
-    var losses = List[SIMD[dtype, 1]]()
+    var losses = List[Scalar[dtype]]()
 
     for i in range(epochs):
         var loss = model.forward(inputs, labels)
@@ -78,8 +78,8 @@ fn run_torch(
     labels: Tensor,
     owned linear1_weights: Tensor,
     owned linear1_bias: Tensor,
-) -> List[SIMD[dtype, 1]]:
-    var out: List[SIMD[dtype, 1]] = List[SIMD[dtype, 1]]()
+) -> List[Scalar[dtype]]:
+    var out: List[Scalar[dtype]] = List[Scalar[dtype]]()
 
     try:
         var torch = Python.import_module("torch")
@@ -122,21 +122,21 @@ fn run_torch(
         return out
 
 
-fn create_weights(num_elements: Int, zero: Bool) -> List[SIMD[dtype, 1]]:
+fn create_weights(num_elements: Int, zero: Bool) -> List[Scalar[dtype]]:
     var prng = MersenneTwister(123456)
-    var weights = List[SIMD[dtype, 1]](capacity=num_elements)
+    var weights = List[Scalar[dtype]](capacity=num_elements)
     for i in range(num_elements):
         if zero:
-            weights.append(SIMD[dtype, 1](0.0))
+            weights.append(Scalar[dtype](0.0))
         else:
             var rand_float = prng.next().cast[dtype]() / max_finite[DType.int32]().cast[
                 dtype
             ]()
-            weights.append(SIMD[dtype, 1](rand_float / 10))
+            weights.append(Scalar[dtype](rand_float / 10))
     return weights ^
 
 
-fn dv_to_tensor(dv: List[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
+fn dv_to_tensor(dv: List[Scalar[dtype]], shape: TensorShape) -> Tensor[dtype]:
     var t = Tensor[dtype](shape)
     if t.num_elements() != len(dv):
         print("[WARNING] tensor and dv not the shame shape")

--- a/test/test_models_sin_estimate.mojo
+++ b/test/test_models_sin_estimate.mojo
@@ -13,12 +13,12 @@ from basalt.utils.rand_utils import MersenneTwister
 
 fn create_simple_nn(
     batch_size: Int,
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
-    linear2_weights: List[SIMD[dtype, 1]],
-    linear2_bias: List[SIMD[dtype, 1]],
-    linear3_weights: List[SIMD[dtype, 1]],
-    linear3_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
+    linear2_weights: List[Scalar[dtype]],
+    linear2_bias: List[Scalar[dtype]],
+    linear3_weights: List[Scalar[dtype]],
+    linear3_bias: List[Scalar[dtype]],
 ) -> Graph:
     var g = Graph()
 
@@ -58,18 +58,18 @@ fn create_simple_nn(
 
 fn run_mojo[
     batch_size: Int,
-    linear1_weights: List[SIMD[dtype, 1]],
-    linear1_bias: List[SIMD[dtype, 1]],
-    linear2_weights: List[SIMD[dtype, 1]],
-    linear2_bias: List[SIMD[dtype, 1]],
-    linear3_weights: List[SIMD[dtype, 1]],
-    linear3_bias: List[SIMD[dtype, 1]],
+    linear1_weights: List[Scalar[dtype]],
+    linear1_bias: List[Scalar[dtype]],
+    linear2_weights: List[Scalar[dtype]],
+    linear2_bias: List[Scalar[dtype]],
+    linear3_weights: List[Scalar[dtype]],
+    linear3_bias: List[Scalar[dtype]],
 ](
     epochs: Int,
     learning_rate: Float64,
     inputs: Tensor[dtype],
     labels: Tensor[dtype],
-) -> List[SIMD[dtype, 1]]:
+) -> List[Scalar[dtype]]:
     alias graph = create_simple_nn(
         batch_size,
         linear1_weights,
@@ -83,7 +83,7 @@ fn run_mojo[
     var model = nn.Model[graph]()
     var optim = nn.optim.Adam[graph](Reference(model.parameters), lr=learning_rate)
 
-    var losses = List[SIMD[dtype, 1]]()
+    var losses = List[Scalar[dtype]]()
 
     for i in range(epochs):
         var loss = model.forward(inputs, labels)
@@ -109,8 +109,8 @@ fn run_torch(
     owned linear2_bias: Tensor,
     owned linear3_weights: Tensor,
     owned linear3_bias: Tensor,
-) -> List[SIMD[dtype, 1]]:
-    var out: List[SIMD[dtype, 1]] = List[SIMD[dtype, 1]]()
+) -> List[Scalar[dtype]]:
+    var out: List[Scalar[dtype]] = List[Scalar[dtype]]()
 
     try:
         var torch = Python.import_module("torch")
@@ -165,21 +165,21 @@ fn run_torch(
         return out
 
 
-fn create_weights(num_elements: Int, zero: Bool) -> List[SIMD[dtype, 1]]:
+fn create_weights(num_elements: Int, zero: Bool) -> List[Scalar[dtype]]:
     var prng = MersenneTwister(123456)
-    var weights = List[SIMD[dtype, 1]](capacity=num_elements)
+    var weights = List[Scalar[dtype]](capacity=num_elements)
     for i in range(num_elements):
         if zero:
-            weights.append(SIMD[dtype, 1](0.0))
+            weights.append(Scalar[dtype](0.0))
         else:
             var rand_float = prng.next().cast[dtype]() / max_finite[DType.int32]().cast[
                 dtype
             ]()
-            weights.append(SIMD[dtype, 1](rand_float / 10))
+            weights.append(Scalar[dtype](rand_float / 10))
     return weights ^
 
 
-fn dv_to_tensor(dv: List[SIMD[dtype, 1]], shape: TensorShape) -> Tensor[dtype]:
+fn dv_to_tensor(dv: List[Scalar[dtype]], shape: TensorShape) -> Tensor[dtype]:
     var t = Tensor[dtype](shape)
     if t.num_elements() != len(dv):
         print("[WARNING] tensor and dv not the shame shape")

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -153,7 +153,7 @@ fn test_elwise_tensor_tensor() raises:
 
 
 fn test_elwise_tensor_scalar() raises:
-    var a: SIMD[dtype, 1] = 2.0
+    var a: Scalar[dtype] = 2.0
     var t1 = Tensor[dtype](2, 10)
     fill(t1, 1.0)
     var result = Tensor[dtype](2, 10)
@@ -222,7 +222,7 @@ fn test_sum_mean_std() raises:
     assert_equal(tensor_mean, s / 20)
 
     var tensor_std = tstd(t)
-    var expected_std: SIMD[dtype, 1] = 0
+    var expected_std: Scalar[dtype] = 0
     for i in range(20):
         expected_std += (i + 1 - tensor_mean) ** 2
     expected_std = sqrt(expected_std / 20)
@@ -287,7 +287,7 @@ fn test_sum_mean_std_n() raises:
     assert_equal(tensor_mean, s / 60)
 
     var tensor_std = tstd(t)
-    var expected_std: SIMD[dtype, 1] = 0
+    var expected_std: Scalar[dtype] = 0
     for i in range(60):
         expected_std += (i + 1 - tensor_mean) ** 2
     expected_std = sqrt(expected_std / 60)


### PR DESCRIPTION
Changed all instanced of `SIMD[Type, 1]` to `Scalar[Type]` as Scalar is a builtin that represents a SIMD[Type, 1], cleans up the code