### PR TITLE
Slice

### DIFF
--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -399,7 +399,7 @@ struct SLICE:
         for i in range(len(positions)):
             idx += positions[i] * strides[i]
 
-        # Copy the data
+        # Copy the data. P.S if the slice dimensions are small, this kernel can be slow (because the worst case for the while loop happens more times).
         for i in range(res_shape.num_elements()):
             res[i] = t1[idx]
 

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -1,5 +1,5 @@
 from algorithm import vectorize
-from math import exp, pow, max, abs
+from math import exp, pow, max, min, abs
 from math.limit import min_finite, max_finite
 
 from basalt import Tensor, TensorShape
@@ -289,6 +289,10 @@ struct SLICE:
         var stop = slice[1] if slice[1] >= 0 else t1_shape[dim] + slice[1]
         var step = slice[2]
 
+        # Ensure start and stop are within bounds.
+        start = max(min(start, t1_shape[dim]), 0)
+        stop = max(min(stop, t1_shape[dim]), 0)
+
         var new_shape = t1_shape
         new_shape[dim] = max(0, (stop - start + abs(step) - 1) // abs(step))
         return new_shape
@@ -298,6 +302,21 @@ struct SLICE:
         t1_shape: TensorShape,
         attributes: AttributeVector,
     ](inout res: Tensor[dtype], t1: Tensor[dtype]):
+        var slice = attributes["slice"].value().to_static[3]()
+        var dim = attributes["dim"].value().to_int() if attributes["dim"] else 0
+
+        var start = slice[0] if slice[0] >= 0 else t1_shape[dim] + slice[0]
+        var stop = slice[1] if slice[1] >= 0 else t1_shape[dim] + slice[1]
+        var step = slice[2]
+
+        # Ensure start and stop are within bounds.
+        start = max(min(start, t1_shape[dim]), 0)
+        stop = max(min(stop, t1_shape[dim]), 0)
+
+        print(start, stop, step)
+        print("SLICE forward not implemented")
+        print(t1)
+        print(res)
         pass
 
     @staticmethod

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -296,7 +296,7 @@ struct SLICE:
         var step = slice[2]
 
         var new_shape = t1_shape
-        new_shape[dim] = max(0, (stop - start + abs(step) - 1) // abs(step))
+        new_shape[dim] = (abs(stop - start) + abs(step) - 1) // abs(step)
         return new_shape
 
     @staticmethod
@@ -319,7 +319,7 @@ struct SLICE:
             return N
         
         alias N = calc_N() # number of elements before slicing dimention
-        alias M = ((stop - start + abs(step) - 1) // abs(step)) # slicing dimention
+        alias M = (abs(stop - start) + abs(step) - 1) // abs(step) # slicing dimention
         alias K = strides[dim] # number of elements after slicing dimention
         
         alias strides = t1_shape.strides()

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,7 +15,7 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE
+from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE
 from .dynamics import CONCAT, SPLIT
 from .conv import CONV2D
 from .pool import MAXPOOL2D
@@ -60,6 +60,7 @@ struct OP(Stringable):
     alias UNSQUEEZE = OP(22, "UNSQUEEZE")
     alias CONCAT = OP(23, "CONCAT", dynamic=True)
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
+    alias SLICE = OP(25, "SLICE")
 
     var id: UInt8
     var name: Bytes[16]
@@ -132,6 +133,8 @@ fn static_result_shape(
         return SQUEEZE.result_shape(t1_shape, attributes)
     elif op == OP.UNSQUEEZE:
         return UNSQUEEZE.result_shape(t1_shape, attributes)
+    elif op == OP.SLICE:
+        return SLICE.result_shape(t1_shape, attributes)
     else:
         print("[ERROR] Operator not found.")
         return TensorShape(-1)
@@ -244,6 +247,8 @@ fn forward_op[
         SQUEEZE.forward[t1_shape, attributes](res, t1)
     elif op == OP.UNSQUEEZE:
         UNSQUEEZE.forward[t1_shape, attributes](res, t1)
+    elif op == OP.SLICE:
+        SLICE.forward[t1_shape, attributes](res, t1)
     else:
         print("[ERROR] Operator not found.")
 
@@ -354,6 +359,8 @@ fn backward_op[
         res_grad = SQUEEZE.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.UNSQUEEZE:
         res_grad = UNSQUEEZE.backward[ug_shape, t1_shape](ug, t1)
+    elif op == OP.SLICE:
+        res_grad = SLICE.backward[ug_shape, t1_shape, attributes](ug, t1)
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -266,34 +266,127 @@ fn test_backward_UNSQUEEZE() raises:
 
 
 fn test_SLICE() raises:
-    alias t1_shape = TensorShape(2, 10)
+    alias t1_shape = TensorShape(3, 4, 5)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(t1.num_elements()):
+        t1[i] = i
+    
+    alias slice = Slice(1, 3, 1)
+
+    # dim = 0
+    var expected_0 = Tensor[dtype](2, 4, 5)
+    for i in range(2):
+        for j in range(4):
+            for k in range(5):
+                expected_0[i*4*5 + j*5 + k] = (i + 1) * 4 * 5 + j * 5 + k
+
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 0)
+        )
+    ](t1, expected_0)
+
+    # dim = 1
+    var expected_1 = Tensor[dtype](3, 2, 5)
+    for i in range(3):
+        for j in range(2):
+            for k in range(5):
+                expected_1[i*2*5 + j*5 + k] = i * 4 * 5 + (j + 1) * 5 + k
+
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 1)
+        )
+    ](t1, expected_1)
+
+    # dim = 2
+    var expected_2 = Tensor[dtype](3, 4, 2)
+    for i in range(3):
+        for j in range(4):
+            for k in range(2):
+                expected_2[i*4*2 + j*2 + k] = i * 4 * 5 + j * 5 + (k + 1)
+        
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 2)
+        )
+    ](t1, expected_2)
+
+
+fn test_SLICE_step() raises:
+    alias slice = Slice(1, 6, 2)
+
+    # dim = 0
+    alias t0_shape = TensorShape(10, 2, 2)
+    var t0: Tensor[dtype] = Tensor[dtype](t0_shape)
+    for i in range(t0.num_elements()):
+        t0[i] = i
+
+    var expected_0 = Tensor[dtype](3, 2, 2)
+    for i in range(3):
+        for j in range(2):
+            for k in range(2):
+                expected_0[i*2*2 + j*2 + k] = (i*2 + 1) * 2 * 2 + j * 2 + k
+
+    test_unary_op[
+        OP.SLICE, t0_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 0)
+        )
+    ](t0, expected_0)
+
+    # dim = 1
+    alias t1_shape = TensorShape(2, 10, 2)
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
     for i in range(t1.num_elements()):
         t1[i] = i
 
-    alias dim = 1
-    alias slice = Slice(0, 10, 2)
-    var expected = Tensor[dtype](2, 5)
-    for i in range(expected.num_elements()):
-        expected[i] = i * 2
-    
+    var expected_1 = Tensor[dtype](2, 3, 2)
+    for i in range(2):
+        for j in range(3):
+            for k in range(2):
+                expected_1[i*3*2 + j*2 + k] = i * 10 * 2 + (j*2 + 1) * 2 + k
+
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
             Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", dim)
+            Attribute("dim", 1)
         )
-    ](t1, expected)
+    ](t1, expected_1)
+
+    # dim = 2
+    alias t2_shape = TensorShape(2, 2, 10)
+    var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
+    for i in range(t2.num_elements()):
+        t2[i] = i
+
+    var expected_2 = Tensor[dtype](2, 2, 3)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                expected_2[i*2*3 + j*3 + k] = i * 2 * 10 + j * 10 + (k*2 + 1)
+
+    test_unary_op[
+        OP.SLICE, t2_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 2)
+        )
+    ](t2, expected_2)
 
 
 fn main():
     try:
-        # test_SIGMOID()
-        # test_RELU()
-        # test_TANH()
-        # test_CLIP()
-        # test_SQUEEZE()
-        # test_UNSQUEEZE()
+        test_SIGMOID()
+        test_RELU()
+        test_TANH()
+        test_CLIP()
+        test_SQUEEZE()
+        test_UNSQUEEZE()
         test_SLICE()
+        test_SLICE_step()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -377,6 +377,67 @@ fn test_SLICE_step() raises:
     ](t2, expected_2)
 
 
+fn test_SLICE_neg() raises:
+    alias slice = Slice(6, 1, -2)
+
+    # dim = 0
+    alias t0_shape = TensorShape(10, 2, 2)
+    var t0: Tensor[dtype] = Tensor[dtype](t0_shape)
+    for i in range(t0.num_elements()):
+        t0[i] = i
+
+    var expected_0 = Tensor[dtype](3, 2, 2)
+    for i in range(3):
+        for j in range(2):
+            for k in range(2):
+                expected_0[i*2*2 + j*2 + k] = StaticIntTuple[3](6, 4, 2)[i] * 2 * 2 + j * 2 + k
+
+    test_unary_op[
+        OP.SLICE, t0_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 0)
+        )
+    ](t0, expected_0)
+
+    # dim = 1
+    alias t1_shape = TensorShape(2, 10, 2)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(t1.num_elements()):
+        t1[i] = i
+
+    var expected_1 = Tensor[dtype](2, 3, 2)
+    for i in range(2):
+        for j in range(3):
+            for k in range(2):
+                expected_1[i*3*2 + j*2 + k] = i * 10 * 2 + StaticIntTuple[3](6, 4, 2)[j] * 2 + k
+
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 1)
+        )
+    ](t1, expected_1)
+
+    # dim = 2
+    alias t2_shape = TensorShape(2, 2, 10)
+    var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
+    for i in range(t2.num_elements()):
+        t2[i] = i
+
+    var expected_2 = Tensor[dtype](2, 2, 3)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                expected_2[i*2*3 + j*3 + k] = i * 2 * 10 + j * 10 + StaticIntTuple[3](6, 4, 2)[k]
+
+    test_unary_op[
+        OP.SLICE, t2_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", 2)
+        )
+    ](t2, expected_2)
+
+
 fn main():
     try:
         test_SIGMOID()
@@ -387,6 +448,7 @@ fn main():
         test_UNSQUEEZE()
         test_SLICE()
         test_SLICE_step()
+        test_SLICE_neg()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -265,27 +265,48 @@ fn test_backward_UNSQUEEZE() raises:
     test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape](t1, ug, expected_grad)
 
 
+fn test_SLICE() raises:
+    alias t1_shape = TensorShape(2, 10)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(t1.num_elements()):
+        t1[i] = i
+
+    alias dim = 1
+    alias slice = Slice(0, 10, 2)
+    var expected = Tensor[dtype](2, 5)
+    for i in range(expected.num_elements()):
+        expected[i] = i * 2
+    
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
+            Attribute("dim", dim)
+        )
+    ](t1, expected)
+
+
 fn main():
     try:
-        test_SIGMOID()
-        test_RELU()
-        test_TANH()
-        test_CLIP()
-        test_SQUEEZE()
-        test_UNSQUEEZE()
+        # test_SIGMOID()
+        # test_RELU()
+        # test_TANH()
+        # test_CLIP()
+        # test_SQUEEZE()
+        # test_UNSQUEEZE()
+        test_SLICE()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
         return
 
-    try:
-        test_backward_SIGMOID()
-        test_backward_RELU()
-        test_backward_TANH()
-        test_backward_CLIP()
-        test_backward_SQUEEZE()
-        test_backward_UNSQUEEZE()
-    except e:
-        print("[ERROR] Error in backward mlops")
-        print(e)
-        return
+    # try:
+    #     test_backward_SIGMOID()
+    #     test_backward_RELU()
+    #     test_backward_TANH()
+    #     test_backward_CLIP()
+    #     test_backward_SQUEEZE()
+    #     test_backward_UNSQUEEZE()
+    # except e:
+    #     print("[ERROR] Error in backward mlops")
+    #     print(e)
+    #     return

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -282,8 +282,10 @@ fn test_SLICE() raises:
 
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 0)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(0))
         )
     ](t1, expected_0)
 
@@ -296,8 +298,10 @@ fn test_SLICE() raises:
 
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 1)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(1))
         )
     ](t1, expected_1)
 
@@ -310,8 +314,10 @@ fn test_SLICE() raises:
         
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 2)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(2))
         )
     ](t1, expected_2)
 
@@ -333,8 +339,10 @@ fn test_SLICE_step() raises:
 
     test_unary_op[
         OP.SLICE, t0_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 0)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(0))
         )
     ](t0, expected_0)
 
@@ -352,8 +360,10 @@ fn test_SLICE_step() raises:
 
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 1)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(1))
         )
     ](t1, expected_1)
 
@@ -371,8 +381,10 @@ fn test_SLICE_step() raises:
 
     test_unary_op[
         OP.SLICE, t2_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 2)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(2))
         )
     ](t2, expected_2)
 
@@ -394,8 +406,10 @@ fn test_SLICE_neg() raises:
 
     test_unary_op[
         OP.SLICE, t0_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 0)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(0))
         )
     ](t0, expected_0)
 
@@ -413,8 +427,10 @@ fn test_SLICE_neg() raises:
 
     test_unary_op[
         OP.SLICE, t1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 1)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(1))
         )
     ](t1, expected_1)
 
@@ -432,8 +448,62 @@ fn test_SLICE_neg() raises:
 
     test_unary_op[
         OP.SLICE, t2_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice.start, slice.end, slice.step)),
-            Attribute("dim", 2)
+            Attribute("starts", TensorShape(slice.start)),
+            Attribute("ends", TensorShape(slice.end)),
+            Attribute("steps", TensorShape(slice.step)),
+            Attribute("axes", TensorShape(2))
+        )
+    ](t2, expected_2)
+
+
+fn test_SLICE_multiple_axes() raises:
+    alias t1_shape = TensorShape(20, 32, 40)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(t1.num_elements()):
+        t1[i] = i
+
+    alias slice_0 = Slice(1, 6, 2)
+    alias slice_1 = Slice(3, 10, 3)
+    alias slice_2 = Slice(5, 15, 2)
+
+    var expected = Tensor[dtype](3, 3, 5)
+    for i in range(3):
+        for j in range(3):
+            for k in range(5):
+                expected[i*3*5 + j*5 + k] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
+    
+    test_unary_op[
+        OP.SLICE, t1_shape, AttributeVector(
+            Attribute("starts", TensorShape(slice_0.start, slice_1.start, slice_2.start)),
+            Attribute("ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)),
+            Attribute("steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)),
+            # Attribute("axes", TensorShape(0, 1, 2))
+        )
+    ](t1, expected)
+
+    alias t2_shape = TensorShape(20, 32, 40, 50)
+    var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
+    for i in range(t2.num_elements()):
+        t2[i] = i
+    
+    alias slice_2_1 = Slice(1, 6, 2)
+    alias slice_2_2 = Slice(3, 10, 3)
+    alias slice_2_3 = Slice(5, 15, 2)
+    alias slice_2_4 = Slice(-43, -30, 4)
+
+    var expected_2 = Tensor[dtype](3, 3, 5, 4)
+
+    for i in range(3):
+        for j in range(3):
+            for k in range(5):
+                for l in range(4):
+                    expected_2[i*3*5*4 + j*5*4 + k*4 + l] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 * 50 + StaticIntTuple[3](3, 6, 9)[j] * 40 * 50 + StaticIntTuple[5](5, 7, 9, 11, 13)[k] * 50 + StaticIntTuple[4](7, 11, 15, 19)[l]
+    
+    test_unary_op[
+        OP.SLICE, t2_shape, AttributeVector(
+            Attribute("starts", TensorShape(slice_2_1.start, slice_2_2.start, slice_2_3.start, slice_2_4.start)),
+            Attribute("ends", TensorShape(slice_2_1.end, slice_2_2.end, slice_2_3.end, slice_2_4.end)),
+            Attribute("steps", TensorShape(slice_2_1.step, slice_2_2.step, slice_2_3.step, slice_2_4.step)),
         )
     ](t2, expected_2)
 
@@ -457,8 +527,10 @@ fn test_backward_SLICE() raises:
 
     test_unary_op_backward[
         OP.SLICE, t0_shape, ug0_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice_0.start, slice_0.end, slice_0.step)),
-            Attribute("dim", 0)
+            Attribute("starts", TensorShape(slice_0.start)),
+            Attribute("ends", TensorShape(slice_0.end)),
+            Attribute("steps", TensorShape(slice_0.step)),
+            Attribute("axes", TensorShape(0))
         )
     ](t0, ug0, expected_ug0)
 
@@ -480,8 +552,10 @@ fn test_backward_SLICE() raises:
 
     test_unary_op_backward[
         OP.SLICE, t1_shape, ug1_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice_1.start, slice_1.end, slice_1.step)),
-            Attribute("dim", 1)
+            Attribute("starts", TensorShape(slice_1.start)),
+            Attribute("ends", TensorShape(slice_1.end)),
+            Attribute("steps", TensorShape(slice_1.step)),
+            Attribute("axes", TensorShape(1))
         )
     ](t1, ug1, expected_ug1)
 
@@ -503,10 +577,47 @@ fn test_backward_SLICE() raises:
 
     test_unary_op_backward[
         OP.SLICE, t2_shape, ug2_shape, AttributeVector(
-            Attribute("slice", StaticIntTuple[3](slice_2.start, slice_2.end, slice_2.step)),
-            Attribute("dim", 2)
+            Attribute("starts", TensorShape(slice_2.start)),
+            Attribute("ends", TensorShape(slice_2.end)),
+            Attribute("steps", TensorShape(slice_2.step)),
+            Attribute("axes", TensorShape(2))
         )
     ](t2, ug2, expected_ug2)
+
+
+fn test_backward_SLICE_multiple_axes() raises:
+    alias t1_shape = TensorShape(20, 32, 40)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    for i in range(t1.num_elements()):
+        t1[i] = i
+
+    alias slice_0 = Slice(1, 6, 2)
+    alias slice_1 = Slice(3, 10, 3)
+    alias slice_2 = Slice(5, 15, 2)
+
+    var expected = Tensor[dtype](3, 3, 5)
+    for i in range(3):
+        for j in range(3):
+            for k in range(5):
+                expected[i*3*5 + j*5 + k] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
+    
+    alias ug_shape = TensorShape(3, 3, 5)
+    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
+    fill(ug, 1.0)
+
+    var expected_ug = Tensor[dtype](t1_shape)
+    for i in range(3):
+        for j in range(3):
+            for k in range(5):
+                expected_ug[StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]] = 1.0
+
+    test_unary_op_backward[
+        OP.SLICE, t1_shape, ug_shape, AttributeVector(
+            Attribute("starts", TensorShape(slice_0.start, slice_1.start, slice_2.start)),
+            Attribute("ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)),
+            Attribute("steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)),
+        )
+    ](t1, ug, expected_ug)
 
 
 fn main():
@@ -520,6 +631,7 @@ fn main():
         test_SLICE()
         test_SLICE_step()
         test_SLICE_neg()
+        test_SLICE_multiple_axes()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
@@ -533,6 +645,7 @@ fn main():
         test_backward_SQUEEZE()
         test_backward_UNSQUEEZE()
         test_backward_SLICE()
+        test_backward_SLICE_multiple_axes()
     except e:
         print("[ERROR] Error in backward mlops")
         print(e)

--- a/tests/python/test_mlops_torch.mojo
+++ b/tests/python/test_mlops_torch.mojo
@@ -121,8 +121,8 @@ fn torch_unary_op(
             to_tensor(input_1.grad.numpy()),
         )
 
-    except:
-        print("Error importing torch")
+    except e:
+        print("Error importing torch", e)
         var d = Tensor[dtype](1)
         return torch_output_unary_op(d, d)
 
@@ -327,12 +327,12 @@ fn test_UNSQUEEZE() raises:
 
 
 fn test_SLICE() raises:
-    alias t1_shape = TensorShape(37, 63, 107)
+    alias t1_shape = TensorShape(430, 322, 317)
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
     rand(t1.data(), t1.num_elements())
 
     # dim = 0
-    alias slice_0 = Slice(5, 24, 3)
+    alias slice_0 = Slice(5, 200, 3)
     alias attrs_0 = AttributeVector(
         Attribute("starts", TensorShape(slice_0.start)),
         Attribute("ends", TensorShape(slice_0.end)),
@@ -340,7 +340,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(0))
     )
 
-    alias ug_shape = TensorShape(7, 63, 107)
+    alias ug_shape = TensorShape(65, 322, 317)
     var ug = Tensor[dtype](ug_shape)
     rand(ug.data(), ug.num_elements())
 
@@ -350,7 +350,7 @@ fn test_SLICE() raises:
     test_unary_op_backward[OP.SLICE, t1_shape, ug_shape, attrs_0](t1, ug, expected_and_grad.grad_1)
 
     # dim = 1
-    alias slice_1 = Slice(10, 50, 5)
+    alias slice_1 = Slice(10, 311, 5)
     alias attrs_1 = AttributeVector(
         Attribute("starts", TensorShape(slice_1.start)),
         Attribute("ends", TensorShape(slice_1.end)),
@@ -358,7 +358,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(1))
     )
 
-    alias ug_shape_1 = TensorShape(37, 8, 107)
+    alias ug_shape_1 = TensorShape(430, 60, 317)
     ug = Tensor[dtype](ug_shape_1)
     rand(ug.data(), ug.num_elements())
 
@@ -368,7 +368,7 @@ fn test_SLICE() raises:
     test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_1, attrs_1](t1, ug, expected_and_grad.grad_1)
 
     # dim = 2
-    alias slice_2 = Slice(99, 33, -7)
+    alias slice_2 = Slice(293, 33, -7)
     alias attrs_2 = AttributeVector(
         Attribute("starts", TensorShape(slice_2.start)),
         Attribute("ends", TensorShape(slice_2.end)),
@@ -376,7 +376,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(2))
     )
 
-    alias ug_shape_2 = TensorShape(37, 63, 10)
+    alias ug_shape_2 = TensorShape(430, 322, 37)
     ug = Tensor[dtype](ug_shape_2)
     rand(ug.data(), ug.num_elements())
 
@@ -388,8 +388,8 @@ fn test_SLICE() raises:
     # Multiple dims
     
     # dim = 0, 1
-    alias slice_0_1 = Slice(5, 24, 3)
-    alias slice_1_1 = Slice(10, 50, 5)
+    alias slice_0_1 = Slice(23, 340, 3)
+    alias slice_1_1 = Slice(10, 250, 5)
 
     alias attrs_0_1 = AttributeVector(
         Attribute("starts", TensorShape(slice_0_1.start, slice_1_1.start)),
@@ -398,7 +398,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(0, 1))
     )
 
-    alias ug_shape_0_1 = TensorShape(7, 8, 107)
+    alias ug_shape_0_1 = TensorShape(106, 48, 317)
     ug = Tensor[dtype](ug_shape_0_1)
     rand(ug.data(), ug.num_elements())
 
@@ -407,18 +407,19 @@ fn test_SLICE() raises:
     test_unary_op[OP.SLICE, t1_shape, attrs_0_1](t1, expected_and_grad.expected)
     test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_1, attrs_0_1](t1, ug, expected_and_grad.grad_1)
 
-    # dim = 0, 1
-    alias slice_0_2 = Slice(-24, -5, 3)
-    alias slice_1_2 = Slice(-10, -50, -5)
+    # dim = 0, 1, 2
+    alias slice_0_2 = Slice(-412, -5, 3)
+    alias slice_1_2 = Slice(-10, -182, -5)
+    alias slice_2_2 = Slice(293, 33, -7)
 
     alias attrs_0_2 = AttributeVector(
-        Attribute("starts", TensorShape(slice_0_2.start, slice_1_2.start)),
-        Attribute("ends", TensorShape(slice_0_2.end, slice_1_2.end)),
-        Attribute("steps", TensorShape(slice_0_2.step, slice_1_2.step)),
+        Attribute("starts", TensorShape(slice_0_2.start, slice_1_2.start, slice_2_2.start)),
+        Attribute("ends", TensorShape(slice_0_2.end, slice_1_2.end, slice_2_2.end)),
+        Attribute("steps", TensorShape(slice_0_2.step, slice_1_2.step, slice_2_2.step)),
         Attribute("axes", TensorShape(0, 1))
     )
 
-    alias ug_shape_0_2 = TensorShape(7, 8, 107)
+    alias ug_shape_0_2 = TensorShape(135, 34, 37)
     ug = Tensor[dtype](ug_shape_0_2)
     rand(ug.data(), ug.num_elements())
 

--- a/tests/python/test_mlops_torch.mojo
+++ b/tests/python/test_mlops_torch.mojo
@@ -358,7 +358,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(1))
     )
 
-    alias ug_shape_1 = TensorShape(430, 60, 317)
+    alias ug_shape_1 = TensorShape(430, 61, 317)
     ug = Tensor[dtype](ug_shape_1)
     rand(ug.data(), ug.num_elements())
 
@@ -376,7 +376,7 @@ fn test_SLICE() raises:
         Attribute("axes", TensorShape(2))
     )
 
-    alias ug_shape_2 = TensorShape(430, 322, 37)
+    alias ug_shape_2 = TensorShape(430, 322, 38)
     ug = Tensor[dtype](ug_shape_2)
     rand(ug.data(), ug.num_elements())
 
@@ -416,14 +416,14 @@ fn test_SLICE() raises:
         Attribute("starts", TensorShape(slice_0_2.start, slice_1_2.start, slice_2_2.start)),
         Attribute("ends", TensorShape(slice_0_2.end, slice_1_2.end, slice_2_2.end)),
         Attribute("steps", TensorShape(slice_0_2.step, slice_1_2.step, slice_2_2.step)),
-        Attribute("axes", TensorShape(0, 1))
+        Attribute("axes", TensorShape(0, 1, 2))
     )
 
-    alias ug_shape_0_2 = TensorShape(135, 34, 37)
+    alias ug_shape_0_2 = TensorShape(136, 35, 38)
     ug = Tensor[dtype](ug_shape_0_2)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_0_2 = PythonObject((slice_0_2.start, slice_0_2.end, slice_0_2.step, 0, slice_1_2.start, slice_1_2.end, slice_1_2.step, 1))
+    var attrs_tuple_0_2 = PythonObject((slice_0_2.start, slice_0_2.end, slice_0_2.step, 0, slice_1_2.start, slice_1_2.end, slice_1_2.step, 1, slice_2_2.start, slice_2_2.end, slice_2_2.step, 2))
     expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0_2)
     test_unary_op[OP.SLICE, t1_shape, attrs_0_2](t1, expected_and_grad.expected)
     test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_2, attrs_0_2](t1, ug, expected_and_grad.grad_1)


### PR DESCRIPTION
Adding the SLICE operator. 
- [x] forward
- [x] backward
- [x] unittests

As it is right now the operator does only support slicing in one dimension at the same time though. And therefore it behaves much more like np.take (https://numpy.org/doc/stable/reference/generated/numpy.take.html) then actual slicing.
We might want to change that and support slicing for mulitple dimensions at the same time. But I just now figured out a parallelized and vectorized version for 1 dim at the time. 