### PR TITLE
Add init and get methods for slice

### DIFF
--- a/basalt/autograd/attributes.mojo
+++ b/basalt/autograd/attributes.mojo
@@ -87,7 +87,7 @@ struct Attribute(Stringable, CollectionElement):
     var type: AttributeType
     var size: Int
 
-    alias Null_Int = int(nan[DType.float64]())
+    alias Null_Int = -14052005
 
     @always_inline("nodebug")
     fn __init__(inout self, name: String, value: String):
@@ -122,7 +122,7 @@ struct Attribute(Stringable, CollectionElement):
             self.data[i] = value[i]
 
     @always_inline("nodebug")
-    fn __init__[N: Int](inout self, name: String, *values: OptionalReg[Int]):
+    fn __init__[N: Int](inout self, name: String, value: StaticTuple[OptionalReg[Int], N]):
         constrained[N < MAX_RANK, "Attribute rank must be less than MAX_RANK."]()
 
         self.data_shape = StaticIntTuple[MAX_RANK]()
@@ -131,9 +131,9 @@ struct Attribute(Stringable, CollectionElement):
         self.type = AttributeType.OPTIONAL_INTS
         self.size = N
 
-        for i in range(len(values)):
-            if values[i]:
-                self.data[i] = values[i].value()
+        for i in range(N):
+            if value[i]:
+                self.data[i] = value[i].value()
             else:
                 self.data[i] = 0
                 self.data_shape[i] = Self.Null_Int

--- a/tests/mojo/test_attributes.mojo
+++ b/tests/mojo/test_attributes.mojo
@@ -1,4 +1,5 @@
 from testing import assert_equal, assert_true
+from collections.optional import OptionalReg
 
 from basalt.nn import TensorShape
 from basalt.autograd.attributes import Attribute
@@ -36,6 +37,15 @@ fn test_attribute_static_int_tuple() raises:
     alias a = Attribute(name="test", value=value)
 
     assert_true(a.to_static[7]() == value)
+
+fn test_attribute_slice() raises:
+    alias value = StaticTuple[OptionalReg[Int], 3](None, None, 2)
+    alias a = Attribute(name="test", value=value)
+
+    var slice = a.to_slice[3]()
+    assert_true(not slice[0].value())
+    assert_true(not slice[1].value())
+    assert_true(slice[2].value() == 2)
 
 
 fn test_attribute_scalar() raises:
@@ -124,6 +134,7 @@ fn main():
         test_attribute_tensor_shape()
         test_attribute_static_int_tuple()
         test_attribute_scalar()
+        test_attribute_slice()
     except e:
         print("[ERROR] Error in attributes")
         print(e)


### PR DESCRIPTION
This pull request adds the `__init__` and `to_slice` methods to the `Attribute` struct. The `__init__` method allows for the initialization of an attribute with optional integer values, while the `to_slice` method converts the attribute data into a static tuple of optional integer values. This addition enhances the functionality of the `Attribute` struct and improves code readability and flexibility.