### PR TITLE
Index

### DIFF
--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -567,4 +567,17 @@ struct INDEX:
         t1_shape: TensorShape,
         attributes: AttributeVector = AttributeVector(),
     ](ug: Tensor[dtype], t1: Tensor[dtype]) -> Tensor[dtype]:
-        return Tensor[dtype]()
+        alias indeces = Self.to_indeces(t1_shape, attributes)
+        alias strides = t1_shape.strides()
+
+        var res_grad = Tensor[dtype](t1_shape)
+
+        var j = 0
+        for comb in product(indeces):
+            var flat_index = 0
+            for dim in range(t1_shape.rank()):
+                flat_index += comb[dim] * strides[dim]
+            res_grad[flat_index] += ug[j]
+            j += 1
+        
+        return res_grad^

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,7 +15,7 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE
+from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE, INDEX
 from .dynamics import CONCAT, SPLIT
 from .conv import CONV2D
 from .pool import MAXPOOL2D
@@ -61,6 +61,7 @@ struct OP(Stringable):
     alias CONCAT = OP(23, "CONCAT", dynamic=True)
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
+    alias INDEX = OP(26, "INDEX")
 
     var id: UInt8
     var name: Bytes[16]
@@ -135,6 +136,8 @@ fn static_result_shape(
         return UNSQUEEZE.result_shape(t1_shape, attributes)
     elif op == OP.SLICE:
         return SLICE.result_shape(t1_shape, attributes)
+    elif op == OP.INDEX:
+        return INDEX.result_shape(t1_shape, attributes)
     else:
         print("[ERROR] Operator not found.")
         return TensorShape(-1)
@@ -249,6 +252,8 @@ fn forward_op[
         UNSQUEEZE.forward[t1_shape, attributes](res, t1)
     elif op == OP.SLICE:
         SLICE.forward[t1_shape, attributes](res, t1)
+    elif op == OP.INDEX:
+        INDEX.forward[t1_shape, attributes](res, t1)
     else:
         print("[ERROR] Operator not found.")
 
@@ -361,6 +366,8 @@ fn backward_op[
         res_grad = UNSQUEEZE.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.SLICE:
         res_grad = SLICE.backward[ug_shape, t1_shape, attributes](ug, t1)
+    elif op == OP.INDEX:
+        res_grad = INDEX.backward[ug_shape, t1_shape, attributes](ug, t1)
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1)

--- a/basalt/utils/itertools.mojo
+++ b/basalt/utils/itertools.mojo
@@ -1,0 +1,47 @@
+
+@value
+struct _ProductIterator(Sized):
+    var lists: List[List[Int]]
+    var indeces: List[Int]
+    var _iters: Int
+
+    @always_inline("nodebug")
+    fn __init__(inout self, lists: List[List[Int]]):
+        self.lists = lists
+        self.indeces = List[Int]()
+        for i in range(len(lists)):
+            self.indeces.append(0)
+        
+        self._iters = 1
+        for lst in self.lists:
+            self._iters *= len(lst[])
+
+    @always_inline("nodebug")
+    fn __len__(self) -> Int:
+        return self._iters
+
+    @always_inline("nodebug")
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline("nodebug")
+    fn __next__(inout self) -> List[Int]:
+        var res = List[Int]()
+        for i in range(len(self.lists)):
+            res.append(self.lists[i][self.indeces[i]])
+        self._increment_indeces()
+        self._iters -= 1
+        return res ^
+
+    @always_inline("nodebug")
+    fn _increment_indeces(inout self):
+        for i in reversed(range(len(self.indeces))):
+            self.indeces[i] += 1
+            if self.indeces[i] < len(self.lists[i]):
+                break
+            self.indeces[i] = 0
+
+
+@always_inline("nodebug")
+fn product(lists: List[List[Int]]) -> _ProductIterator:
+    return _ProductIterator(lists)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -649,6 +649,36 @@ fn test_INDEX() raises:
     print(expected)
 
 
+fn test_INDEX_backward() raises:
+    alias t1_shape = TensorShape(2, 3, 5)
+    var t = Tensor[dtype](t1_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    alias attr_1 = Attribute("dim_1i", TensorShape(0, 0))
+    alias attr_2 = Attribute("dim_2s", TensorShape(0, 5, 2))
+
+    alias ug_shape = TensorShape(2, 2, 3)
+    var ug = Tensor[dtype](ug_shape)
+    fill(ug, 1.0)
+
+    var expected = Tensor[dtype](t1_shape)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                # NOTE: `+=` because selected indeces [0, 0] can repeat
+                expected[i * 3 * 5 + k * 2] += 1.0 
+
+    test_unary_op_backward[
+        OP.INDEX, t1_shape, ug_shape, AttributeVector(
+            attr_1,
+            attr_2,
+        )
+    ](t, ug, expected)
+
+    print(expected)
+
+
 fn main():
     try:
         # test_SIGMOID()
@@ -667,16 +697,17 @@ fn main():
         print(e)
         return
 
-    # try:
-    #     test_backward_SIGMOID()
-    #     test_backward_RELU()
-    #     test_backward_TANH()
-    #     test_backward_CLIP()
-    #     test_backward_SQUEEZE()
-    #     test_backward_UNSQUEEZE()
-    #     test_backward_SLICE()
-    #     test_backward_SLICE_multiple_axes()
-    # except e:
-    #     print("[ERROR] Error in backward mlops")
-    #     print(e)
-    #     return
+    try:
+        # test_backward_SIGMOID()
+        # test_backward_RELU()
+        # test_backward_TANH()
+        # test_backward_CLIP()
+        # test_backward_SQUEEZE()
+        # test_backward_UNSQUEEZE()
+        # test_backward_SLICE()
+        # test_backward_SLICE_multiple_axes()
+        test_INDEX_backward()
+    except e:
+        print("[ERROR] Error in backward mlops")
+        print(e)
+        return

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -620,33 +620,63 @@ fn test_backward_SLICE_multiple_axes() raises:
     ](t1, ug, expected_ug)
 
 
+from basalt.autograd.ops.mlops import INDEX
+
+fn test_INDEX() raises:
+    alias t1_shape = TensorShape(2, 3, 5)
+    var t = Tensor[dtype](t1_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    # t[:, [0, 0], 0:5:2]
+    # TODO: need for a list attribute as this only supports to specify indeces of MAX_RANK
+    alias attr_1 = Attribute("dim_1i", TensorShape(0, 0))
+    alias attr_2 = Attribute("dim_2s", TensorShape(0, 5, 2))
+
+    var expected = Tensor[dtype](2, 2, 3)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                expected[i*2*3 + j*3 + k] = i * 3 * 5 + k * 2
+
+    test_unary_op[
+        OP.INDEX, t1_shape, AttributeVector(
+            attr_1,
+            attr_2,
+        )
+    ](t, expected)
+
+    print(expected)
+
+
 fn main():
     try:
-        test_SIGMOID()
-        test_RELU()
-        test_TANH()
-        test_CLIP()
-        test_SQUEEZE()
-        test_UNSQUEEZE()
-        test_SLICE()
-        test_SLICE_step()
-        test_SLICE_neg()
-        test_SLICE_multiple_axes()
+        # test_SIGMOID()
+        # test_RELU()
+        # test_TANH()
+        # test_CLIP()
+        # test_SQUEEZE()
+        # test_UNSQUEEZE()
+        # test_SLICE()
+        # test_SLICE_step()
+        # test_SLICE_neg()
+        # test_SLICE_multiple_axes()
+        test_INDEX()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
         return
 
-    try:
-        test_backward_SIGMOID()
-        test_backward_RELU()
-        test_backward_TANH()
-        test_backward_CLIP()
-        test_backward_SQUEEZE()
-        test_backward_UNSQUEEZE()
-        test_backward_SLICE()
-        test_backward_SLICE_multiple_axes()
-    except e:
-        print("[ERROR] Error in backward mlops")
-        print(e)
-        return
+    # try:
+    #     test_backward_SIGMOID()
+    #     test_backward_RELU()
+    #     test_backward_TANH()
+    #     test_backward_CLIP()
+    #     test_backward_SQUEEZE()
+    #     test_backward_UNSQUEEZE()
+    #     test_backward_SLICE()
+    #     test_backward_SLICE_multiple_axes()
+    # except e:
+    #     print("[ERROR] Error in backward mlops")
+    #     print(e)
+    #     return


### PR DESCRIPTION
INDEX: An extension on SLICE that adds the ability to select values form a tensor based on specified indeces (or slices).
Note that it also adds the ability to duplicate values from a dimension. (This feature is used in upsampling)

Short demo of the expected behaviour:
```
t = torch.arange(2*2).reshape(2, 2).float().requires_grad_(True)

r = t[:, [0, 0, 0]]
print(r) # tensor([[0., 0., 0.], [2., 2., 2.]], grad_fn=<IndexBackward0>)

ug = torch.ones_like(r)
r.backward(ug)
print(t.grad) # tensor([[3., 0.], [3., 0.]])
```

- [] fw index (done but not optimized)
- [] bw index
- [] unittests for both