### PR TITLE
Implement leaky_relu

### DIFF
--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -54,14 +54,14 @@ struct THRESHOLD:
         ]()
 
         @always_inline
-        fn threshold[
+        fn threshold_bw[
             type: DType, simd_width: Int
         ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
             return (x > x.splat(THRESHOLD.cast[type]())).select[type](1, 0)
 
         var res_grad = Tensor[dtype](t1_shape)
 
-        elwise_transform[threshold](res_grad, t1)
+        elwise_transform[threshold_bw](res_grad, t1)
 
         return res_grad^
 

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -208,6 +208,72 @@ struct TANH:
         return res_grad^
 
 
+struct HARDTANH:
+    @staticmethod
+    fn result_shape(t1_shape: TensorShape) -> TensorShape:
+        return t1_shape
+
+    @staticmethod
+    fn forward[
+        t1_shape: TensorShape,
+        attributes: AttributeVector,
+    ](inout res: Tensor[dtype], t1: Tensor[dtype]):
+        """Forward pass for hard tanh."""
+
+        alias MIN_VAL: Scalar[dtype] = attributes["min_val"].value().to_scalar[
+            dtype
+        ]()
+
+        alias MAX_VAL: Scalar[dtype] = attributes["max_val"].value().to_scalar[
+            dtype
+        ]()
+
+        @always_inline
+        fn hardtanh[
+            type: DType, simd_width: Int
+        ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
+            alias casted_min = MIN_VAL.cast[type]()
+            alias casted_max = MAX_VAL.cast[type]()
+
+            var x_or_min = (x > x.splat(casted_min)).select[type](x, casted_min)
+
+            return (x_or_min < x_or_min.splat(casted_max)).select[type](
+                x_or_min, casted_max
+            )
+
+        elwise_transform[hardtanh](res, t1)
+
+    @staticmethod
+    fn backward[
+        ug_shape: TensorShape,
+        t1_shape: TensorShape,
+        attributes: AttributeVector,
+    ](ug: Tensor[dtype], t1: Tensor[dtype]) -> Tensor[dtype]:
+        """Backward pass for hard tanh."""
+        alias MIN_VAL: Scalar[dtype] = attributes["min_val"].value().to_scalar[
+            dtype
+        ]()
+
+        alias MAX_VAL: Scalar[dtype] = attributes["max_val"].value().to_scalar[
+            dtype
+        ]()
+
+        @always_inline
+        fn hardtanh_bw[
+            type: DType, simd_width: Int
+        ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
+            return (
+                x > x.splat(MIN_VAL.cast[type]())
+                and x < x.splat(MAX_VAL.cast[type]())
+            ).select[type](1, 0)
+
+        var res_grad = Tensor[dtype](t1_shape)
+
+        elwise_transform[hardtanh_bw](res_grad, t1)
+
+        return res_grad^
+
+
 struct CLIP:
     @staticmethod
     fn result_shape(t_shape: TensorShape) -> TensorShape:

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -31,9 +31,10 @@ struct THRESHOLD:
         fn threshold[
             type: DType, simd_width: Int
         ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
-            return (x > x.splat(THRESHOLD.cast[type]())).select[type](
-                x, VALUE.cast[type]()
-            )  # Feels like using AttributeVector made this unnecessarily complicated
+            alias casted_threshold = THRESHOLD.cast[type]()
+            alias casted_value = VALUE.cast[type]()
+
+            return (x > x.splat(casted_threshold)).select[type](x, casted_value)
 
         elwise_transform[threshold](res, t1)
 

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -19,6 +19,7 @@ from .mlops import (
     THRESHOLD,
     SIGMOID,
     RELU,
+    LEAKYRELU,
     TANH,
     HARDTANH,
     CLIP,
@@ -73,6 +74,7 @@ struct OP(Stringable):
     alias SLICE = OP(25, "SLICE")
     alias THRESHOLD = OP(26, "THRESHOLD")
     alias HARDTANH = OP(27, "HARDTANH")
+    alias LEAKYRELU = OP(28, "LEAKYRELU")
 
     var id: UInt8
     var name: Bytes[16]
@@ -141,6 +143,8 @@ fn static_result_shape(
         return SIGMOID.result_shape(t1_shape)
     elif op == OP.RELU:
         return RELU.result_shape(t1_shape)
+    elif op == OP.LEAKYRELU:
+        return LEAKYRELU.result_shape(t1_shape)
     elif op == OP.TANH:
         return TANH.result_shape(t1_shape)
     elif op == OP.HARDTANH:
@@ -259,6 +263,8 @@ fn forward_op[
         SIGMOID.forward[t1_shape](res, t1)
     elif op == OP.RELU:
         RELU.forward[t1_shape](res, t1)
+    elif op == OP.LEAKYRELU:
+        LEAKYRELU.forward[t1_shape, attributes](res, t1)
     elif op == OP.TANH:
         TANH.forward[t1_shape](res, t1)
     elif op == OP.HARDTANH:
@@ -381,6 +387,8 @@ fn backward_op[
         res_grad = SIGMOID.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RELU:
         res_grad = RELU.backward[ug_shape, t1_shape](ug, t1)
+    elif op == OP.LEAKYRELU:
+        res_grad = LEAKYRELU.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.TANH:
         res_grad = TANH.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.HARDTANH:

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -20,6 +20,7 @@ from .mlops import (
     SIGMOID,
     RELU,
     TANH,
+    HARDTANH,
     CLIP,
     SQUEEZE,
     UNSQUEEZE,
@@ -71,6 +72,7 @@ struct OP(Stringable):
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
     alias THRESHOLD = OP(26, "THRESHOLD")
+    alias HARDTANH = OP(27, "HARDTANH")
 
     var id: UInt8
     var name: Bytes[16]
@@ -141,6 +143,8 @@ fn static_result_shape(
         return RELU.result_shape(t1_shape)
     elif op == OP.TANH:
         return TANH.result_shape(t1_shape)
+    elif op == OP.HARDTANH:
+        return HARDTANH.result_shape(t1_shape)
     elif op == OP.TRANSPOSE:
         return TRANSPOSE.result_shape(t1_shape, attributes)
     elif op == OP.MAXPOOL2D:
@@ -257,6 +261,8 @@ fn forward_op[
         RELU.forward[t1_shape](res, t1)
     elif op == OP.TANH:
         TANH.forward[t1_shape](res, t1)
+    elif op == OP.HARDTANH:
+        HARDTANH.forward[t1_shape, attributes](res, t1)
     elif op == OP.TRANSPOSE:
         TRANSPOSE.forward[t1_shape, attributes](res, t1)
     elif op == OP.MAXPOOL2D:
@@ -377,6 +383,8 @@ fn backward_op[
         res_grad = RELU.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.TANH:
         res_grad = TANH.backward[ug_shape, t1_shape](ug, t1)
+    elif op == OP.HARDTANH:
+        res_grad = HARDTANH.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.TRANSPOSE:
         res_grad = TRANSPOSE.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.MAXPOOL2D:

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -16,12 +16,10 @@ from .basics import (
     FMA,
 )
 from .mlops import (
-    THRESHOLD,
     SIGMOID,
     RELU,
     LEAKYRELU,
     TANH,
-    HARDTANH,
     CLIP,
     SQUEEZE,
     UNSQUEEZE,
@@ -72,8 +70,6 @@ struct OP(Stringable):
     alias CONCAT = OP(23, "CONCAT", dynamic=True)
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
-    alias THRESHOLD = OP(26, "THRESHOLD")
-    alias HARDTANH = OP(27, "HARDTANH")
     alias LEAKYRELU = OP(28, "LEAKYRELU")
 
     var id: UInt8
@@ -137,8 +133,6 @@ fn static_result_shape(
         return FLATTEN.result_shape(t1_shape)
     elif op == OP.RESHAPE:
         return RESHAPE.result_shape(t1_shape, attributes)
-    elif op == OP.THRESHOLD:
-        return THRESHOLD.result_shape(t1_shape)
     elif op == OP.SIGMOID:
         return SIGMOID.result_shape(t1_shape)
     elif op == OP.RELU:
@@ -147,8 +141,6 @@ fn static_result_shape(
         return LEAKYRELU.result_shape(t1_shape)
     elif op == OP.TANH:
         return TANH.result_shape(t1_shape)
-    elif op == OP.HARDTANH:
-        return HARDTANH.result_shape(t1_shape)
     elif op == OP.TRANSPOSE:
         return TRANSPOSE.result_shape(t1_shape, attributes)
     elif op == OP.MAXPOOL2D:
@@ -257,8 +249,6 @@ fn forward_op[
         FLATTEN.forward[t1_shape](res, t1)
     elif op == OP.RESHAPE:
         RESHAPE.forward[t1_shape](res, t1)
-    elif op == OP.THRESHOLD:
-        THRESHOLD.forward[t1_shape, attributes](res, t1)
     elif op == OP.SIGMOID:
         SIGMOID.forward[t1_shape](res, t1)
     elif op == OP.RELU:
@@ -267,8 +257,6 @@ fn forward_op[
         LEAKYRELU.forward[t1_shape, attributes](res, t1)
     elif op == OP.TANH:
         TANH.forward[t1_shape](res, t1)
-    elif op == OP.HARDTANH:
-        HARDTANH.forward[t1_shape, attributes](res, t1)
     elif op == OP.TRANSPOSE:
         TRANSPOSE.forward[t1_shape, attributes](res, t1)
     elif op == OP.MAXPOOL2D:
@@ -381,8 +369,6 @@ fn backward_op[
         res_grad = FLATTEN.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RESHAPE:
         res_grad = RESHAPE.backward[ug_shape, t1_shape](ug, t1)
-    elif op == OP.THRESHOLD:
-        res_grad = THRESHOLD.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.SIGMOID:
         res_grad = SIGMOID.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RELU:
@@ -391,8 +377,6 @@ fn backward_op[
         res_grad = LEAKYRELU.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.TANH:
         res_grad = TANH.backward[ug_shape, t1_shape](ug, t1)
-    elif op == OP.HARDTANH:
-        res_grad = HARDTANH.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.TRANSPOSE:
         res_grad = TRANSPOSE.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.MAXPOOL2D:

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -370,7 +370,7 @@ fn backward_op[
     elif op == OP.RESHAPE:
         res_grad = RESHAPE.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.THRESHOLD:
-        res_grad = THRESHOLD.backward[ug_shape, t1_shape](ug, t1)
+        res_grad = THRESHOLD.backward[ug_shape, t1_shape, attributes](ug, t1)
     elif op == OP.SIGMOID:
         res_grad = SIGMOID.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RELU:

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,7 +15,16 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE
+from .mlops import (
+    THRESHOLD,
+    SIGMOID,
+    RELU,
+    TANH,
+    CLIP,
+    SQUEEZE,
+    UNSQUEEZE,
+    SLICE,
+)
 from .dynamics import CONCAT, SPLIT
 from .conv import CONV2D
 from .pool import MAXPOOL2D
@@ -61,6 +70,7 @@ struct OP(Stringable):
     alias CONCAT = OP(23, "CONCAT", dynamic=True)
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
+    alias THRESHOLD = OP(26, "THRESHOLD")
 
     var id: UInt8
     var name: Bytes[16]
@@ -87,10 +97,16 @@ fn static_result_shape(
     if len(operands) == 1:
         return static_result_shape(op, operands[0].shape, attributes)
     elif len(operands) == 2:
-        return static_result_shape(op, operands[0].shape, operands[1].shape, attributes)
+        return static_result_shape(
+            op, operands[0].shape, operands[1].shape, attributes
+        )
     elif len(operands) == 3:
         return static_result_shape(
-            op, operands[0].shape, operands[1].shape, operands[2].shape, attributes
+            op,
+            operands[0].shape,
+            operands[1].shape,
+            operands[2].shape,
+            attributes,
         )
     else:
         print("Error: Invalid number of operands")
@@ -117,6 +133,8 @@ fn static_result_shape(
         return FLATTEN.result_shape(t1_shape)
     elif op == OP.RESHAPE:
         return RESHAPE.result_shape(t1_shape, attributes)
+    elif op == OP.THRESHOLD:
+        return THRESHOLD.result_shape(t1_shape)
     elif op == OP.SIGMOID:
         return SIGMOID.result_shape(t1_shape)
     elif op == OP.RELU:
@@ -231,6 +249,8 @@ fn forward_op[
         FLATTEN.forward[t1_shape](res, t1)
     elif op == OP.RESHAPE:
         RESHAPE.forward[t1_shape](res, t1)
+    elif op == OP.THRESHOLD:
+        THRESHOLD.forward[t1_shape, attributes](res, t1)
     elif op == OP.SIGMOID:
         SIGMOID.forward[t1_shape](res, t1)
     elif op == OP.RELU:
@@ -254,7 +274,10 @@ fn forward_op[
 
 
 fn forward_op[
-    op: OP, t1_shape: TensorShape, t2_shape: TensorShape, attributes: AttributeVector
+    op: OP,
+    t1_shape: TensorShape,
+    t2_shape: TensorShape,
+    attributes: AttributeVector,
 ](inout res: Tensor[dtype], t1: Tensor[dtype], t2: Tensor[dtype]):
     """
     Forward pass for binary operators.
@@ -283,14 +306,21 @@ fn forward_op[
     t2_shape: TensorShape,
     t3_shape: TensorShape,
     attributes: AttributeVector,
-](inout res: Tensor[dtype], t1: Tensor[dtype], t2: Tensor[dtype], t3: Tensor[dtype]):
+](
+    inout res: Tensor[dtype],
+    t1: Tensor[dtype],
+    t2: Tensor[dtype],
+    t3: Tensor[dtype],
+):
     """
     Forward pass for ternary operators.
     """
 
     @parameter
     if op == OP.CONV2D:
-        CONV2D.forward[t1_shape, t2_shape, t3_shape, attributes](res, t1, t2, t3)
+        CONV2D.forward[t1_shape, t2_shape, t3_shape, attributes](
+            res, t1, t2, t3
+        )
     elif op == OP.FMA:
         FMA.forward[t1_shape, t2_shape, t3_shape](res, t1, t2, t3)
     else:
@@ -300,11 +330,7 @@ fn forward_op[
 fn forward_op[
     op: OP,
     attributes: AttributeVector,
-](
-    inputs: List[Symbol],
-    outputs: List[Symbol],
-    parameters: Parameters,
-):
+](inputs: List[Symbol], outputs: List[Symbol], parameters: Parameters,):
     """
     Forward pass for dynamic operators.
     """
@@ -343,6 +369,8 @@ fn backward_op[
         res_grad = FLATTEN.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RESHAPE:
         res_grad = RESHAPE.backward[ug_shape, t1_shape](ug, t1)
+    elif op == OP.THRESHOLD:
+        res_grad = THRESHOLD.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.SIGMOID:
         res_grad = SIGMOID.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.RELU:
@@ -375,7 +403,12 @@ fn backward_op[
     t1_shape: TensorShape,
     t2_shape: TensorShape,
     attributes: AttributeVector,
-](ug: Tensor[dtype], t1: Tensor[dtype], t2: Tensor[dtype], inout grad: Tensor[dtype]):
+](
+    ug: Tensor[dtype],
+    t1: Tensor[dtype],
+    t2: Tensor[dtype],
+    inout grad: Tensor[dtype],
+):
     """
     Backward pass for binary operators.
     """
@@ -383,17 +416,29 @@ fn backward_op[
 
     @parameter
     if op == OP.ADD:
-        res_grad = ADD.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = ADD.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     elif op == OP.SUB:
-        res_grad = SUB.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = SUB.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     elif op == OP.MUL:
-        res_grad = MUL.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = MUL.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     elif op == OP.DIV:
-        res_grad = DIV.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = DIV.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     elif op == OP.POW:
-        res_grad = POW.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = POW.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     elif op == OP.DOT:
-        res_grad = DOT.backward[tensor_id, ug_shape, t1_shape, t2_shape](ug, t1, t2)
+        res_grad = DOT.backward[tensor_id, ug_shape, t1_shape, t2_shape](
+            ug, t1, t2
+        )
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1, -1)
@@ -437,9 +482,9 @@ fn backward_op[
             tensor_id, ug_shape, t1_shape, t2_shape, t3_shape, attributes
         ](ug, t1, t2, t3)
     elif op == OP.FMA:
-        res_grad = FMA.backward[tensor_id, ug_shape, t1_shape, t2_shape, t3_shape](
-            ug, t1, t2, t3
-        )
+        res_grad = FMA.backward[
+            tensor_id, ug_shape, t1_shape, t2_shape, t3_shape
+        ](ug, t1, t2, t3)
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1, -1)
@@ -463,9 +508,13 @@ fn backward_op[
     var res_grad: Tensor[dtype]
 
     if op == OP.CONCAT:
-        res_grad = CONCAT.backward[input_id, attributes](inputs, outputs, parameters)
+        res_grad = CONCAT.backward[input_id, attributes](
+            inputs, outputs, parameters
+        )
     elif op == OP.SPLIT:
-        res_grad = SPLIT.backward[input_id, attributes](inputs, outputs, parameters)
+        res_grad = SPLIT.backward[input_id, attributes](
+            inputs, outputs, parameters
+        )
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1, -1)

--- a/basalt/nn/__init__.mojo
+++ b/basalt/nn/__init__.mojo
@@ -6,4 +6,12 @@ from .layers.conv import Conv2d
 from .layers.pool import MaxPool2d
 
 from .loss import MSELoss, CrossEntropyLoss
-from .activations import Softmax, LogSoftmax, ReLU, Sigmoid, Tanh, Threshold
+from .activations import (
+    Softmax,
+    LogSoftmax,
+    ReLU,
+    Sigmoid,
+    Tanh,
+    Hardtanh,
+    Threshold,
+)

--- a/basalt/nn/__init__.mojo
+++ b/basalt/nn/__init__.mojo
@@ -6,4 +6,4 @@ from .layers.conv import Conv2d
 from .layers.pool import MaxPool2d
 
 from .loss import MSELoss, CrossEntropyLoss
-from .activations import Softmax, LogSoftmax, ReLU, Sigmoid, Tanh
+from .activations import Softmax, LogSoftmax, ReLU, Sigmoid, Tanh, Threshold

--- a/basalt/nn/__init__.mojo
+++ b/basalt/nn/__init__.mojo
@@ -10,6 +10,7 @@ from .activations import (
     Softmax,
     LogSoftmax,
     ReLU,
+    LeakyReLU,
     Sigmoid,
     Tanh,
     Hardtanh,

--- a/basalt/nn/__init__.mojo
+++ b/basalt/nn/__init__.mojo
@@ -13,6 +13,4 @@ from .activations import (
     LeakyReLU,
     Sigmoid,
     Tanh,
-    Hardtanh,
-    Threshold,
 )

--- a/basalt/nn/activations.mojo
+++ b/basalt/nn/activations.mojo
@@ -2,7 +2,21 @@ from basalt import Tensor, TensorShape
 from basalt import Graph, Symbol, OP
 from basalt.autograd.attributes import Attribute, AttributeVector
 
+
 # '''Activation functions.'''
+fn Threshold(
+    inout g: Graph,
+    input: Symbol,
+    threshold: Scalar[dtype],
+    value: Scalar[dtype],
+) -> Symbol:
+    return g.op(
+        OP.THRESHOLD,
+        input,
+        attributes=AttributeVector(
+            Attribute("threshold", threshold), Attribute("value", value)
+        ),
+    )
 
 
 fn ReLU(inout g: Graph, input: Symbol) -> Symbol:

--- a/basalt/nn/activations.mojo
+++ b/basalt/nn/activations.mojo
@@ -31,6 +31,21 @@ fn Tanh(inout g: Graph, input: Symbol) -> Symbol:
     return g.op(OP.TANH, input)
 
 
+fn Hardtanh(
+    inout g: Graph,
+    input: Symbol,
+    min_val: Scalar[dtype],
+    max_val: Scalar[dtype],
+) -> Symbol:
+    return g.op(
+        OP.HARDTANH,
+        input,
+        attributes=AttributeVector(
+            Attribute("min_val", min_val), Attribute("max_val", max_val)
+        ),
+    )
+
+
 fn Softmax(inout g: Graph, input: Symbol, axis: Int) -> Symbol:
     # softmax: exp(x_i) / sum(exp(x_j))
     # stable softmax: exp(x_i - max(x_j)) / sum(exp(x_j - max(x_j)))

--- a/basalt/nn/activations.mojo
+++ b/basalt/nn/activations.mojo
@@ -23,6 +23,16 @@ fn ReLU(inout g: Graph, input: Symbol) -> Symbol:
     return g.op(OP.RELU, input)
 
 
+fn LeakyReLU(
+    inout g: Graph, input: Symbol, negative_slope: Scalar[dtype]
+) -> Symbol:
+    return g.op(
+        OP.LEAKYRELU,
+        input,
+        attributes=AttributeVector(Attribute("negative_slope", negative_slope)),
+    )
+
+
 fn Sigmoid(inout g: Graph, input: Symbol) -> Symbol:
     return g.op(OP.SIGMOID, input)
 

--- a/basalt/nn/activations.mojo
+++ b/basalt/nn/activations.mojo
@@ -4,21 +4,6 @@ from basalt.autograd.attributes import Attribute, AttributeVector
 
 
 # '''Activation functions.'''
-fn Threshold(
-    inout g: Graph,
-    input: Symbol,
-    threshold: Scalar[dtype],
-    value: Scalar[dtype],
-) -> Symbol:
-    return g.op(
-        OP.THRESHOLD,
-        input,
-        attributes=AttributeVector(
-            Attribute("threshold", threshold), Attribute("value", value)
-        ),
-    )
-
-
 fn ReLU(inout g: Graph, input: Symbol) -> Symbol:
     return g.op(OP.RELU, input)
 
@@ -39,21 +24,6 @@ fn Sigmoid(inout g: Graph, input: Symbol) -> Symbol:
 
 fn Tanh(inout g: Graph, input: Symbol) -> Symbol:
     return g.op(OP.TANH, input)
-
-
-fn Hardtanh(
-    inout g: Graph,
-    input: Symbol,
-    min_val: Scalar[dtype],
-    max_val: Scalar[dtype],
-) -> Symbol:
-    return g.op(
-        OP.HARDTANH,
-        input,
-        attributes=AttributeVector(
-            Attribute("min_val", min_val), Attribute("max_val", max_val)
-        ),
-    )
 
 
 fn Softmax(inout g: Graph, input: Symbol, axis: Int) -> Symbol:

--- a/tests/mojo/test_activations.mojo
+++ b/tests/mojo/test_activations.mojo
@@ -10,6 +10,7 @@ from basalt.nn import (
     ReLU,
     Sigmoid,
     Tanh,
+    Hardtanh,
     Threshold,
 )
 from basalt.autograd import Graph, Symbol
@@ -208,13 +209,43 @@ fn test_TANH() raises:
     test_graph[shape, Tanh, nodes](input, expected)
 
 
+fn test_HARDTANH() raises:
+    alias shape = TensorShape(3, 3)
+    alias nodes = 1
+
+    alias MIN_VAL = -2
+    alias MAX_VAL = 2
+
+    var input = Tensor[dtype](shape)
+
+    for i in range(9):
+        input[i] = i - 4
+
+    var expected = Tensor[dtype](shape)
+
+    for j in range(0, 9):
+        var i = j - 4
+        if i < MIN_VAL:
+            expected[j] = MIN_VAL
+
+        elif i > MAX_VAL:
+            expected[j] = MAX_VAL
+
+        else:
+            expected[j] = i
+
+    test_graph[shape, Hardtanh, nodes, MIN_VAL, MAX_VAL](input, expected)
+
+
 fn main():
     try:
+        test_THRESHOLD()
         test_SOFTMAX()
         test_LOGSOFTMAX()
         test_RELU()
         test_SIGMOID()
         test_TANH()
+        test_HARDTANH()
     except e:
         print("[ERROR] Error in activations")
         print(e)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -1,11 +1,59 @@
 from basalt import dtype, nelts
 from basalt.autograd import OP
 from basalt.autograd.attributes import AttributeVector, Attribute
-from basalt.autograd.ops.mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE
+from basalt.autograd.ops.mlops import (
+    SIGMOID,
+    RELU,
+    THRESHOLD,
+    LEAKYRELU,
+    TANH,
+    HARDTANH,
+    CLIP,
+    SQUEEZE,
+    UNSQUEEZE,
+)
 from basalt.nn import Tensor, TensorShape
 from basalt.utils.tensorutils import fill
 
-from tests import assert_tensors_equal, test_unary_op, test_unary_op_backward, to_numpy
+from tests import (
+    assert_tensors_equal,
+    test_unary_op,
+    test_unary_op_backward,
+    to_numpy,
+)
+
+
+fn test_THRESHOLD() raises:
+    alias t1_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    fill(t1, 4.0)
+
+    var expected = Tensor[dtype](2, 3)
+    fill(expected, 4.0)
+
+    test_unary_op[
+        OP.THRESHOLD,
+        t1_shape,
+        AttributeVector(Attribute("threshold", 3), Attribute("value", 2)),
+    ](t1, expected)
+
+
+fn test_backward_THRESHOLD() raises:
+    alias t1_shape = TensorShape(2, 3)
+    alias ug_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
+    fill(ug, 2.0)
+
+    var expected_grad = Tensor[dtype](2, 3)
+    fill(expected_grad, 0)
+
+    test_unary_op_backward[
+        OP.THRESHOLD,
+        t1_shape,
+        ug_shape,
+        AttributeVector(Attribute("threshold", 3), Attribute("value", 2)),
+    ](t1, ug, expected_grad)
 
 
 fn test_SIGMOID() raises:

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -78,7 +78,9 @@ fn test_backward_SIGMOID() raises:
         expected_grad, 5.0 * 0.25
     )  # 0.25 = d(sigmoid(0))/dx = sigmoid(0) * (1 - sigmoid(0))
 
-    test_unary_op_backward[OP.SIGMOID, t1_shape, ug_shape](t1, ug, expected_grad)
+    test_unary_op_backward[OP.SIGMOID, t1_shape, ug_shape](
+        t1, ug, expected_grad
+    )
 
 
 fn test_RELU() raises:
@@ -237,7 +239,9 @@ fn test_CLIP() raises:
     for i in range(6):
         var val = Scalar[dtype](i - 3)
         expected_min[i] = val if (val > -1.1) else -1.1
-    test_unary_op[OP.CLIP, t1_shape, AttributeVector(min_attr)](t1, expected_min)
+    test_unary_op[OP.CLIP, t1_shape, AttributeVector(min_attr)](
+        t1, expected_min
+    )
 
     # Clip with max
     alias max_attr = Attribute("max", 1.1)
@@ -245,7 +249,9 @@ fn test_CLIP() raises:
     for i in range(6):
         var val = Scalar[dtype](i - 3)
         expected_max[i] = val if (val < 1.1) else 1.1
-    test_unary_op[OP.CLIP, t1_shape, AttributeVector(max_attr)](t1, expected_max)
+    test_unary_op[OP.CLIP, t1_shape, AttributeVector(max_attr)](
+        t1, expected_max
+    )
 
     # Clip with min and max
     var expected = Tensor[dtype](2, 3)
@@ -257,7 +263,9 @@ fn test_CLIP() raises:
             expected[i] = 1.1
         else:
             expected[i] = val
-    test_unary_op[OP.CLIP, t1_shape, AttributeVector(min_attr, max_attr)](t1, expected)
+    test_unary_op[OP.CLIP, t1_shape, AttributeVector(min_attr, max_attr)](
+        t1, expected
+    )
 
 
 fn test_backward_CLIP() raises:
@@ -279,7 +287,9 @@ fn test_backward_CLIP() raises:
     for i in range(6):
         var val = Scalar[dtype](i - 3)
         expected_min[i] = 5.0 if (val > -1.1) else 0.0
-    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, min_attr](t1, ug, expected_min)
+    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, min_attr](
+        t1, ug, expected_min
+    )
 
     # Clip with max
     alias max_attr = AttributeVector(Attribute("max", 1.1))
@@ -287,7 +297,9 @@ fn test_backward_CLIP() raises:
     for i in range(6):
         var val = Scalar[dtype](i - 3)
         expected_max[i] = 5.0 if (val < 1.1) else 0.0
-    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, max_attr](t1, ug, expected_max)
+    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, max_attr](
+        t1, ug, expected_max
+    )
 
     # Clip with min and max
     alias attrs = AttributeVector(Attribute("min", -1.1), Attribute("max", 1.1))
@@ -328,7 +340,9 @@ fn test_SQUEEZE() raises:
     expected = Tensor[dtype](1, 2, 3)
     fill(expected, 5.0)
     test_unary_op[
-        OP.SQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(2, 4)))
+        OP.SQUEEZE,
+        t1_shape,
+        AttributeVector(Attribute("dims", TensorShape(2, 4))),
     ](t1, expected)
 
 
@@ -343,7 +357,9 @@ fn test_backward_SQUEEZE() raises:
     var expected_grad = Tensor[dtype](2, 1, 3, 1)
     fill(expected_grad, 5.0)
 
-    test_unary_op_backward[OP.SQUEEZE, t1_shape, ug_shape](t1, ug, expected_grad)
+    test_unary_op_backward[OP.SQUEEZE, t1_shape, ug_shape](
+        t1, ug, expected_grad
+    )
 
 
 fn test_UNSQUEEZE() raises:
@@ -355,26 +371,34 @@ fn test_UNSQUEEZE() raises:
     var expected = Tensor[dtype](2, 1, 3, 1)
     fill(expected, 5.0)
     test_unary_op[
-        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1, 3)))
+        OP.UNSQUEEZE,
+        t1_shape,
+        AttributeVector(Attribute("dims", TensorShape(1, 3))),
     ](t1, expected)
 
     expected = Tensor[dtype](2, 1, 3)
     fill(expected, 5.0)
 
     test_unary_op[
-        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(1)))
+        OP.UNSQUEEZE,
+        t1_shape,
+        AttributeVector(Attribute("dims", TensorShape(1))),
     ](t1, expected)
 
     expected = Tensor[dtype](1, 2, 3)
     fill(expected, 5.0)
     test_unary_op[
-        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-3)))
+        OP.UNSQUEEZE,
+        t1_shape,
+        AttributeVector(Attribute("dims", TensorShape(-3))),
     ](t1, expected)
 
     expected = Tensor[dtype](2, 1, 3, 1)
     fill(expected, 5.0)
     test_unary_op[
-        OP.UNSQUEEZE, t1_shape, AttributeVector(Attribute("dims", TensorShape(-1, -3)))
+        OP.UNSQUEEZE,
+        t1_shape,
+        AttributeVector(Attribute("dims", TensorShape(-1, -3))),
     ](t1, expected)
 
 
@@ -389,7 +413,9 @@ fn test_backward_UNSQUEEZE() raises:
     var expected_grad = Tensor[dtype](2, 3)
     fill(expected_grad, 5.0)
 
-    test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape](t1, ug, expected_grad)
+    test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape](
+        t1, ug, expected_grad
+    )
 
 
 fn test_SLICE() raises:
@@ -397,7 +423,7 @@ fn test_SLICE() raises:
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
     for i in range(t1.num_elements()):
         t1[i] = i
-    
+
     alias slice = Slice(1, 3, 1)
 
     # dim = 0
@@ -405,15 +431,17 @@ fn test_SLICE() raises:
     for i in range(2):
         for j in range(4):
             for k in range(5):
-                expected_0[i*4*5 + j*5 + k] = (i + 1) * 4 * 5 + j * 5 + k
+                expected_0[i * 4 * 5 + j * 5 + k] = (i + 1) * 4 * 5 + j * 5 + k
 
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(0))
-        )
+            Attribute("axes", TensorShape(0)),
+        ),
     ](t1, expected_0)
 
     # dim = 1
@@ -421,15 +449,17 @@ fn test_SLICE() raises:
     for i in range(3):
         for j in range(2):
             for k in range(5):
-                expected_1[i*2*5 + j*5 + k] = i * 4 * 5 + (j + 1) * 5 + k
+                expected_1[i * 2 * 5 + j * 5 + k] = i * 4 * 5 + (j + 1) * 5 + k
 
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(1))
-        )
+            Attribute("axes", TensorShape(1)),
+        ),
     ](t1, expected_1)
 
     # dim = 2
@@ -437,15 +467,17 @@ fn test_SLICE() raises:
     for i in range(3):
         for j in range(4):
             for k in range(2):
-                expected_2[i*4*2 + j*2 + k] = i * 4 * 5 + j * 5 + (k + 1)
-        
+                expected_2[i * 4 * 2 + j * 2 + k] = i * 4 * 5 + j * 5 + (k + 1)
+
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(2))
-        )
+            Attribute("axes", TensorShape(2)),
+        ),
     ](t1, expected_2)
 
 
@@ -462,15 +494,19 @@ fn test_SLICE_step() raises:
     for i in range(3):
         for j in range(2):
             for k in range(2):
-                expected_0[i*2*2 + j*2 + k] = (i*2 + 1) * 2 * 2 + j * 2 + k
+                expected_0[i * 2 * 2 + j * 2 + k] = (
+                    (i * 2 + 1) * 2 * 2 + j * 2 + k
+                )
 
     test_unary_op[
-        OP.SLICE, t0_shape, AttributeVector(
+        OP.SLICE,
+        t0_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(0))
-        )
+            Attribute("axes", TensorShape(0)),
+        ),
     ](t0, expected_0)
 
     # dim = 1
@@ -483,15 +519,19 @@ fn test_SLICE_step() raises:
     for i in range(2):
         for j in range(3):
             for k in range(2):
-                expected_1[i*3*2 + j*2 + k] = i * 10 * 2 + (j*2 + 1) * 2 + k
+                expected_1[i * 3 * 2 + j * 2 + k] = (
+                    i * 10 * 2 + (j * 2 + 1) * 2 + k
+                )
 
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(1))
-        )
+            Attribute("axes", TensorShape(1)),
+        ),
     ](t1, expected_1)
 
     # dim = 2
@@ -504,15 +544,19 @@ fn test_SLICE_step() raises:
     for i in range(2):
         for j in range(2):
             for k in range(3):
-                expected_2[i*2*3 + j*3 + k] = i * 2 * 10 + j * 10 + (k*2 + 1)
+                expected_2[i * 2 * 3 + j * 3 + k] = (
+                    i * 2 * 10 + j * 10 + (k * 2 + 1)
+                )
 
     test_unary_op[
-        OP.SLICE, t2_shape, AttributeVector(
+        OP.SLICE,
+        t2_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(2))
-        )
+            Attribute("axes", TensorShape(2)),
+        ),
     ](t2, expected_2)
 
 
@@ -529,15 +573,19 @@ fn test_SLICE_neg() raises:
     for i in range(3):
         for j in range(2):
             for k in range(2):
-                expected_0[i*2*2 + j*2 + k] = StaticIntTuple[3](6, 4, 2)[i] * 2 * 2 + j * 2 + k
+                expected_0[i * 2 * 2 + j * 2 + k] = (
+                    StaticIntTuple[3](6, 4, 2)[i] * 2 * 2 + j * 2 + k
+                )
 
     test_unary_op[
-        OP.SLICE, t0_shape, AttributeVector(
+        OP.SLICE,
+        t0_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(0))
-        )
+            Attribute("axes", TensorShape(0)),
+        ),
     ](t0, expected_0)
 
     # dim = 1
@@ -550,15 +598,19 @@ fn test_SLICE_neg() raises:
     for i in range(2):
         for j in range(3):
             for k in range(2):
-                expected_1[i*3*2 + j*2 + k] = i * 10 * 2 + StaticIntTuple[3](6, 4, 2)[j] * 2 + k
+                expected_1[i * 3 * 2 + j * 2 + k] = (
+                    i * 10 * 2 + StaticIntTuple[3](6, 4, 2)[j] * 2 + k
+                )
 
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(1))
-        )
+            Attribute("axes", TensorShape(1)),
+        ),
     ](t1, expected_1)
 
     # dim = 2
@@ -571,15 +623,19 @@ fn test_SLICE_neg() raises:
     for i in range(2):
         for j in range(2):
             for k in range(3):
-                expected_2[i*2*3 + j*3 + k] = i * 2 * 10 + j * 10 + StaticIntTuple[3](6, 4, 2)[k]
+                expected_2[i * 2 * 3 + j * 3 + k] = (
+                    i * 2 * 10 + j * 10 + StaticIntTuple[3](6, 4, 2)[k]
+                )
 
     test_unary_op[
-        OP.SLICE, t2_shape, AttributeVector(
+        OP.SLICE,
+        t2_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice.start)),
             Attribute("ends", TensorShape(slice.end)),
             Attribute("steps", TensorShape(slice.step)),
-            Attribute("axes", TensorShape(2))
-        )
+            Attribute("axes", TensorShape(2)),
+        ),
     ](t2, expected_2)
 
 
@@ -597,22 +653,35 @@ fn test_SLICE_multiple_axes() raises:
     for i in range(3):
         for j in range(3):
             for k in range(5):
-                expected[i*3*5 + j*5 + k] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
-    
+                expected[i * 3 * 5 + j * 5 + k] = (
+                    StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40
+                    + StaticIntTuple[3](3, 6, 9)[j] * 40
+                    + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
+                )
+
     test_unary_op[
-        OP.SLICE, t1_shape, AttributeVector(
-            Attribute("starts", TensorShape(slice_0.start, slice_1.start, slice_2.start)),
-            Attribute("ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)),
-            Attribute("steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)),
+        OP.SLICE,
+        t1_shape,
+        AttributeVector(
+            Attribute(
+                "starts",
+                TensorShape(slice_0.start, slice_1.start, slice_2.start),
+            ),
+            Attribute(
+                "ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)
+            ),
+            Attribute(
+                "steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)
+            ),
             # Attribute("axes", TensorShape(0, 1, 2))
-        )
+        ),
     ](t1, expected)
 
     alias t2_shape = TensorShape(20, 32, 40, 50)
     var t2: Tensor[dtype] = Tensor[dtype](t2_shape)
     for i in range(t2.num_elements()):
         t2[i] = i
-    
+
     alias slice_2_1 = Slice(1, 6, 2)
     alias slice_2_2 = Slice(3, 10, 3)
     alias slice_2_3 = Slice(5, 15, 2)
@@ -624,14 +693,42 @@ fn test_SLICE_multiple_axes() raises:
         for j in range(3):
             for k in range(5):
                 for l in range(4):
-                    expected_2[i*3*5*4 + j*5*4 + k*4 + l] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 * 50 + StaticIntTuple[3](3, 6, 9)[j] * 40 * 50 + StaticIntTuple[5](5, 7, 9, 11, 13)[k] * 50 + StaticIntTuple[4](7, 11, 15, 19)[l]
-    
+                    expected_2[i * 3 * 5 * 4 + j * 5 * 4 + k * 4 + l] = (
+                        StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 * 50
+                        + StaticIntTuple[3](3, 6, 9)[j] * 40 * 50
+                        + StaticIntTuple[5](5, 7, 9, 11, 13)[k] * 50
+                        + StaticIntTuple[4](7, 11, 15, 19)[l]
+                    )
+
     test_unary_op[
-        OP.SLICE, t2_shape, AttributeVector(
-            Attribute("starts", TensorShape(slice_2_1.start, slice_2_2.start, slice_2_3.start, slice_2_4.start)),
-            Attribute("ends", TensorShape(slice_2_1.end, slice_2_2.end, slice_2_3.end, slice_2_4.end)),
-            Attribute("steps", TensorShape(slice_2_1.step, slice_2_2.step, slice_2_3.step, slice_2_4.step)),
-        )
+        OP.SLICE,
+        t2_shape,
+        AttributeVector(
+            Attribute(
+                "starts",
+                TensorShape(
+                    slice_2_1.start,
+                    slice_2_2.start,
+                    slice_2_3.start,
+                    slice_2_4.start,
+                ),
+            ),
+            Attribute(
+                "ends",
+                TensorShape(
+                    slice_2_1.end, slice_2_2.end, slice_2_3.end, slice_2_4.end
+                ),
+            ),
+            Attribute(
+                "steps",
+                TensorShape(
+                    slice_2_1.step,
+                    slice_2_2.step,
+                    slice_2_3.step,
+                    slice_2_4.step,
+                ),
+            ),
+        ),
     ](t2, expected_2)
 
 
@@ -650,15 +747,18 @@ fn test_backward_SLICE() raises:
     for i in range(2):
         for j in range(4):
             for k in range(5):
-                expected_ug0[(i+1)*4*5 + j*5 + k] = 1.0
+                expected_ug0[(i + 1) * 4 * 5 + j * 5 + k] = 1.0
 
     test_unary_op_backward[
-        OP.SLICE, t0_shape, ug0_shape, AttributeVector(
+        OP.SLICE,
+        t0_shape,
+        ug0_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice_0.start)),
             Attribute("ends", TensorShape(slice_0.end)),
             Attribute("steps", TensorShape(slice_0.step)),
-            Attribute("axes", TensorShape(0))
-        )
+            Attribute("axes", TensorShape(0)),
+        ),
     ](t0, ug0, expected_ug0)
 
     # dim = 1 (step = 2)
@@ -670,20 +770,23 @@ fn test_backward_SLICE() raises:
     alias ug1_shape = TensorShape(2, 3, 2)
     var ug1: Tensor[dtype] = Tensor[dtype](ug1_shape)
     fill(ug1, 1.0)
-    
+
     var expected_ug1 = Tensor[dtype](t1_shape)
     for i in range(2):
         for j in range(3):
             for k in range(2):
-                expected_ug1[i*10*2 + (j*2 + 1)*2 + k] = 1.0
+                expected_ug1[i * 10 * 2 + (j * 2 + 1) * 2 + k] = 1.0
 
     test_unary_op_backward[
-        OP.SLICE, t1_shape, ug1_shape, AttributeVector(
+        OP.SLICE,
+        t1_shape,
+        ug1_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice_1.start)),
             Attribute("ends", TensorShape(slice_1.end)),
             Attribute("steps", TensorShape(slice_1.step)),
-            Attribute("axes", TensorShape(1))
-        )
+            Attribute("axes", TensorShape(1)),
+        ),
     ](t1, ug1, expected_ug1)
 
     # dim = 2 (step = -2)
@@ -700,15 +803,20 @@ fn test_backward_SLICE() raises:
     for i in range(2):
         for j in range(2):
             for k in range(3):
-                expected_ug2[i*2*10 + j*10 + StaticIntTuple[3](6, 4, 2)[k]] = 1.0
+                expected_ug2[
+                    i * 2 * 10 + j * 10 + StaticIntTuple[3](6, 4, 2)[k]
+                ] = 1.0
 
     test_unary_op_backward[
-        OP.SLICE, t2_shape, ug2_shape, AttributeVector(
+        OP.SLICE,
+        t2_shape,
+        ug2_shape,
+        AttributeVector(
             Attribute("starts", TensorShape(slice_2.start)),
             Attribute("ends", TensorShape(slice_2.end)),
             Attribute("steps", TensorShape(slice_2.step)),
-            Attribute("axes", TensorShape(2))
-        )
+            Attribute("axes", TensorShape(2)),
+        ),
     ](t2, ug2, expected_ug2)
 
 
@@ -726,8 +834,12 @@ fn test_backward_SLICE_multiple_axes() raises:
     for i in range(3):
         for j in range(3):
             for k in range(5):
-                expected[i*3*5 + j*5 + k] = StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
-    
+                expected[i * 3 * 5 + j * 5 + k] = (
+                    StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40
+                    + StaticIntTuple[3](3, 6, 9)[j] * 40
+                    + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
+                )
+
     alias ug_shape = TensorShape(3, 3, 5)
     var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
     fill(ug, 1.0)
@@ -736,14 +848,28 @@ fn test_backward_SLICE_multiple_axes() raises:
     for i in range(3):
         for j in range(3):
             for k in range(5):
-                expected_ug[StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40 + StaticIntTuple[3](3, 6, 9)[j] * 40 + StaticIntTuple[5](5, 7, 9, 11, 13)[k]] = 1.0
+                expected_ug[
+                    StaticIntTuple[5](1, 3, 5, 7, 9)[i] * 32 * 40
+                    + StaticIntTuple[3](3, 6, 9)[j] * 40
+                    + StaticIntTuple[5](5, 7, 9, 11, 13)[k]
+                ] = 1.0
 
     test_unary_op_backward[
-        OP.SLICE, t1_shape, ug_shape, AttributeVector(
-            Attribute("starts", TensorShape(slice_0.start, slice_1.start, slice_2.start)),
-            Attribute("ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)),
-            Attribute("steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)),
-        )
+        OP.SLICE,
+        t1_shape,
+        ug_shape,
+        AttributeVector(
+            Attribute(
+                "starts",
+                TensorShape(slice_0.start, slice_1.start, slice_2.start),
+            ),
+            Attribute(
+                "ends", TensorShape(slice_0.end, slice_1.end, slice_2.end)
+            ),
+            Attribute(
+                "steps", TensorShape(slice_0.step, slice_1.step, slice_2.step)
+            ),
+        ),
     ](t1, ug, expected_ug)
 
 

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -189,6 +189,38 @@ fn test_backward_TANH() raises:
     test_unary_op_backward[OP.TANH, t1_shape, ug_shape](t1, ug, expected_grad)
 
 
+fn test_HARDTANH() raises:
+    alias t1_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+
+    var expected = Tensor[dtype](2, 3)
+    fill(expected, 0.0)
+
+    test_unary_op[
+        OP.HARDTANH,
+        t1_shape,
+        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
+    ](t1, expected)
+
+
+fn test_backward_HARDTANH() raises:
+    alias t1_shape = TensorShape(2, 3)
+    alias ug_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
+    fill(ug, 5.0)
+
+    var expected_grad = Tensor[dtype](2, 3)
+    fill(expected_grad, 0)  # 5 > 3, so slope is 0.
+
+    test_unary_op_backward[
+        OP.HARDTANH,
+        t1_shape,
+        ug_shape,
+        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
+    ](t1, ug, expected_grad)
+
+
 fn test_CLIP() raises:
     alias t1_shape = TensorShape(2, 3)
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -119,6 +119,53 @@ fn test_backward_RELU() raises:
     test_unary_op_backward[OP.RELU, t1_shape, ug_shape](t1, ug, expected_grad)
 
 
+fn test_LEAKYRELU() raises:
+    alias t1_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    # TODO: When tensors can do slices, this could be changed to two fill functions.
+    for i in range(3):
+        t1[i] = 3
+    for i in range(3, 6):
+        t1[i] = -3
+
+    var expected = Tensor[dtype](2, 3)
+    for i in range(3):
+        expected[i] = 3
+    for i in range(3, 6):
+        expected[i] = -0.3
+
+    test_unary_op[
+        OP.LEAKYRELU,
+        t1_shape,
+        AttributeVector(Attribute("negative_slope", 0.1)),
+    ](t1, expected)
+
+
+fn test_backward_LEAKYRELU() raises:
+    alias t1_shape = TensorShape(2, 3)
+    alias ug_shape = TensorShape(2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
+    for i in range(3):
+        t1[i] = 3
+    for i in range(3, 6):
+        t1[i] = -3
+    fill(ug, 5.0)
+
+    var expected_grad = Tensor[dtype](2, 3)
+    for i in range(3):
+        expected_grad[i] = 1 * 5.0
+    for i in range(3, 6):
+        expected_grad[i] = 0.1 * 5.0
+
+    test_unary_op_backward[
+        OP.LEAKYRELU,
+        t1_shape,
+        ug_shape,
+        AttributeVector(Attribute("negative_slope", 0.1)),
+    ](t1, ug, expected_grad)
+
+
 fn test_TANH() raises:
     alias t1_shape = TensorShape(2, 3)
     var t1: Tensor[dtype] = Tensor[dtype](t1_shape)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -4,10 +4,8 @@ from basalt.autograd.attributes import AttributeVector, Attribute
 from basalt.autograd.ops.mlops import (
     SIGMOID,
     RELU,
-    THRESHOLD,
     LEAKYRELU,
     TANH,
-    HARDTANH,
     CLIP,
     SQUEEZE,
     UNSQUEEZE,
@@ -21,39 +19,6 @@ from tests import (
     test_unary_op_backward,
     to_numpy,
 )
-
-
-fn test_THRESHOLD() raises:
-    alias t1_shape = TensorShape(2, 3)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-    fill(t1, 4.0)
-
-    var expected = Tensor[dtype](2, 3)
-    fill(expected, 4.0)
-
-    test_unary_op[
-        OP.THRESHOLD,
-        t1_shape,
-        AttributeVector(Attribute("threshold", 3), Attribute("value", 2)),
-    ](t1, expected)
-
-
-fn test_backward_THRESHOLD() raises:
-    alias t1_shape = TensorShape(2, 3)
-    alias ug_shape = TensorShape(2, 3)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
-    fill(ug, 2.0)
-
-    var expected_grad = Tensor[dtype](2, 3)
-    fill(expected_grad, 0)
-
-    test_unary_op_backward[
-        OP.THRESHOLD,
-        t1_shape,
-        ug_shape,
-        AttributeVector(Attribute("threshold", 3), Attribute("value", 2)),
-    ](t1, ug, expected_grad)
 
 
 fn test_SIGMOID() raises:
@@ -189,38 +154,6 @@ fn test_backward_TANH() raises:
     fill(expected_grad, 5.0 * 1.0)  # 1.0 = d(tanh(0))/dx = 1 - tanh(0)^2
 
     test_unary_op_backward[OP.TANH, t1_shape, ug_shape](t1, ug, expected_grad)
-
-
-fn test_HARDTANH() raises:
-    alias t1_shape = TensorShape(2, 3)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-
-    var expected = Tensor[dtype](2, 3)
-    fill(expected, 0.0)
-
-    test_unary_op[
-        OP.HARDTANH,
-        t1_shape,
-        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
-    ](t1, expected)
-
-
-fn test_backward_HARDTANH() raises:
-    alias t1_shape = TensorShape(2, 3)
-    alias ug_shape = TensorShape(2, 3)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-    var ug: Tensor[dtype] = Tensor[dtype](ug_shape)
-    fill(ug, 5.0)
-
-    var expected_grad = Tensor[dtype](2, 3)
-    fill(expected_grad, 0)  # 5 > 3, so slope is 0.
-
-    test_unary_op_backward[
-        OP.HARDTANH,
-        t1_shape,
-        ug_shape,
-        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
-    ](t1, ug, expected_grad)
 
 
 fn test_CLIP() raises:

--- a/tests/python/test_mlops_torch.mojo
+++ b/tests/python/test_mlops_torch.mojo
@@ -47,6 +47,11 @@ fn torch_unary_op(
             expected = torch.sigmoid(input_1)
         elif op == OP.RELU:
             expected = torch.relu(input_1)
+        elif op == OP.LEAKYRELU:
+            expected = torch.nn.functional.leaky_relu(
+                input_1,
+                attrs.value()["negative_slope"].value().to_scalar[dtype](),
+            )
         elif op == OP.TANH:
             expected = torch.tanh(input_1)
         elif op == OP.CLIP:
@@ -65,7 +70,9 @@ fn torch_unary_op(
                 var dim = attrs["dims"]
 
                 if dim:
-                    expected = torch.squeeze(input_1, dim=dim.value().to_shape()[0])
+                    expected = torch.squeeze(
+                        input_1, dim=dim.value().to_shape()[0]
+                    )
                 else:
                     expected = torch.squeeze(input_1)
             elif attrs_tuple:
@@ -78,7 +85,9 @@ fn torch_unary_op(
                 var dim = attrs["dims"]
 
                 if dim:
-                    expected = torch.unsqueeze(input_1, dim=dim.value().to_shape()[0])
+                    expected = torch.unsqueeze(
+                        input_1, dim=dim.value().to_shape()[0]
+                    )
                 else:
                     expected = torch.unsqueeze(input_1, 0)
             elif attrs_tuple:
@@ -102,11 +111,11 @@ fn torch_unary_op(
 
                 if step < 0:
                     flip_dims.append(dim)
-                    step = step *- 1
+                    step = step * -1
                     end, start = (end + 1) * -1, (start + 1) * -1
 
                 indices[dim] = py.slice(start, end, step)
-            
+
             expected = input_1.flip(flip_dims)[indices]
         else:
             print("Error: op not supported (returning the value input_1): ", op)
@@ -159,6 +168,31 @@ fn test_RELU() raises:
     )
 
 
+fn test_LEAKYRELU() raises:
+    alias t1_shape = TensorShape(37, 63, 107)
+    alias ug_shape = TensorShape(37, 63, 107)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    rand(t1.data(), t1.num_elements())
+
+    var ug = Tensor[dtype](ug_shape)
+    rand(ug.data(), ug.num_elements())
+
+    var expected_and_grad = torch_unary_op(
+        OP.LEAKYRELU, t1, ug, AttributeVector(Attribute("negative_slope", 0.1))
+    )
+    test_unary_op[
+        OP.LEAKYRELU,
+        t1_shape,
+        AttributeVector(Attribute("negative_slope", 0.1)),
+    ](t1, expected_and_grad.expected)
+    test_unary_op_backward[
+        OP.LEAKYRELU,
+        t1_shape,
+        ug_shape,
+        AttributeVector(Attribute("negative_slope", 0.1)),
+    ](t1, ug, expected_and_grad.grad_1)
+
+
 fn test_TANH() raises:
     alias t1_shape = TensorShape(37, 63, 107)
     alias ug_shape = TensorShape(37, 63, 107)
@@ -193,23 +227,27 @@ fn test_CLIP() raises:
 
     # Clip with min
     alias min_attr = Attribute("min", 0.3333)
-    expected_and_grad = torch_unary_op(OP.CLIP, t1, ug, AttributeVector(min_attr))
+    expected_and_grad = torch_unary_op(
+        OP.CLIP, t1, ug, AttributeVector(min_attr)
+    )
     test_unary_op[OP.CLIP, t1_shape, AttributeVector(min_attr)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, AttributeVector(min_attr)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.CLIP, t1_shape, ug_shape, AttributeVector(min_attr)
+    ](t1, ug, expected_and_grad.grad_1)
 
     # Clip with max
     alias max_attr = Attribute("max", 0.6666)
-    expected_and_grad = torch_unary_op(OP.CLIP, t1, ug, AttributeVector(max_attr))
+    expected_and_grad = torch_unary_op(
+        OP.CLIP, t1, ug, AttributeVector(max_attr)
+    )
     test_unary_op[OP.CLIP, t1_shape, AttributeVector(max_attr)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.CLIP, t1_shape, ug_shape, AttributeVector(max_attr)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.CLIP, t1_shape, ug_shape, AttributeVector(max_attr)
+    ](t1, ug, expected_and_grad.grad_1)
 
     # Clip with min and max
     expected_and_grad = torch_unary_op(
@@ -249,9 +287,9 @@ fn test_SQUEEZE() raises:
     test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(dim)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.SQUEEZE, t1_shape, ug_shape_1, AttributeVector(dim)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.SQUEEZE, t1_shape, ug_shape_1, AttributeVector(dim)
+    ](t1, ug, expected_and_grad.grad_1)
 
     alias ug_shape_2 = TensorShape(20, 28, 1)
     ug = Tensor[dtype](ug_shape_2)
@@ -259,13 +297,15 @@ fn test_SQUEEZE() raises:
 
     alias dim_2 = Attribute("dims", TensorShape(1))
 
-    expected_and_grad = torch_unary_op(OP.SQUEEZE, t1, ug, AttributeVector(dim_2))
+    expected_and_grad = torch_unary_op(
+        OP.SQUEEZE, t1, ug, AttributeVector(dim_2)
+    )
     test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(dim_2)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.SQUEEZE, t1_shape, ug_shape_2, AttributeVector(dim_2)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.SQUEEZE, t1_shape, ug_shape_2, AttributeVector(dim_2)
+    ](t1, ug, expected_and_grad.grad_1)
 
     # Squeeze with multiple dims
     ug = Tensor[dtype](ug_shape)
@@ -282,9 +322,9 @@ fn test_SQUEEZE() raises:
     test_unary_op[OP.SQUEEZE, t1_shape, AttributeVector(dims)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.SQUEEZE, t1_shape, ug_shape, AttributeVector(dims)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.SQUEEZE, t1_shape, ug_shape, AttributeVector(dims)
+    ](t1, ug, expected_and_grad.grad_1)
 
 
 fn test_UNSQUEEZE() raises:
@@ -298,13 +338,15 @@ fn test_UNSQUEEZE() raises:
 
     alias dim = Attribute("dims", TensorShape(1))
 
-    var expected_and_grad = torch_unary_op(OP.UNSQUEEZE, t1, ug, AttributeVector(dim))
+    var expected_and_grad = torch_unary_op(
+        OP.UNSQUEEZE, t1, ug, AttributeVector(dim)
+    )
     test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(dim)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape, AttributeVector(dim)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.UNSQUEEZE, t1_shape, ug_shape, AttributeVector(dim)
+    ](t1, ug, expected_and_grad.grad_1)
 
     # Unsqueeze with multiple dims
     alias ug_shape_2 = TensorShape(20, 1, 28, 1)
@@ -321,9 +363,9 @@ fn test_UNSQUEEZE() raises:
     test_unary_op[OP.UNSQUEEZE, t1_shape, AttributeVector(dims)](
         t1, expected_and_grad.expected
     )
-    test_unary_op_backward[OP.UNSQUEEZE, t1_shape, ug_shape_2, AttributeVector(dims)](
-        t1, ug, expected_and_grad.grad_1
-    )
+    test_unary_op_backward[
+        OP.UNSQUEEZE, t1_shape, ug_shape_2, AttributeVector(dims)
+    ](t1, ug, expected_and_grad.grad_1)
 
 
 fn test_SLICE() raises:
@@ -337,17 +379,23 @@ fn test_SLICE() raises:
         Attribute("starts", TensorShape(slice_0.start)),
         Attribute("ends", TensorShape(slice_0.end)),
         Attribute("steps", TensorShape(slice_0.step)),
-        Attribute("axes", TensorShape(0))
+        Attribute("axes", TensorShape(0)),
     )
 
     alias ug_shape = TensorShape(65, 322, 317)
     var ug = Tensor[dtype](ug_shape)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_0 = PythonObject((slice_0.start, slice_0.end, slice_0.step, 0))
-    var expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0)
+    var attrs_tuple_0 = PythonObject(
+        (slice_0.start, slice_0.end, slice_0.step, 0)
+    )
+    var expected_and_grad = torch_unary_op(
+        OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0
+    )
     test_unary_op[OP.SLICE, t1_shape, attrs_0](t1, expected_and_grad.expected)
-    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape, attrs_0](t1, ug, expected_and_grad.grad_1)
+    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape, attrs_0](
+        t1, ug, expected_and_grad.grad_1
+    )
 
     # dim = 1
     alias slice_1 = Slice(10, 311, 5)
@@ -355,17 +403,23 @@ fn test_SLICE() raises:
         Attribute("starts", TensorShape(slice_1.start)),
         Attribute("ends", TensorShape(slice_1.end)),
         Attribute("steps", TensorShape(slice_1.step)),
-        Attribute("axes", TensorShape(1))
+        Attribute("axes", TensorShape(1)),
     )
 
     alias ug_shape_1 = TensorShape(430, 61, 317)
     ug = Tensor[dtype](ug_shape_1)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_1 = PythonObject((slice_1.start, slice_1.end, slice_1.step, 1))
-    expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_1)
+    var attrs_tuple_1 = PythonObject(
+        (slice_1.start, slice_1.end, slice_1.step, 1)
+    )
+    expected_and_grad = torch_unary_op(
+        OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_1
+    )
     test_unary_op[OP.SLICE, t1_shape, attrs_1](t1, expected_and_grad.expected)
-    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_1, attrs_1](t1, ug, expected_and_grad.grad_1)
+    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_1, attrs_1](
+        t1, ug, expected_and_grad.grad_1
+    )
 
     # dim = 2
     alias slice_2 = Slice(293, 33, -7)
@@ -373,20 +427,26 @@ fn test_SLICE() raises:
         Attribute("starts", TensorShape(slice_2.start)),
         Attribute("ends", TensorShape(slice_2.end)),
         Attribute("steps", TensorShape(slice_2.step)),
-        Attribute("axes", TensorShape(2))
+        Attribute("axes", TensorShape(2)),
     )
 
     alias ug_shape_2 = TensorShape(430, 322, 38)
     ug = Tensor[dtype](ug_shape_2)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_2 = PythonObject((slice_2.start, slice_2.end, slice_2.step, 2))
-    expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_2)
+    var attrs_tuple_2 = PythonObject(
+        (slice_2.start, slice_2.end, slice_2.step, 2)
+    )
+    expected_and_grad = torch_unary_op(
+        OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_2
+    )
     test_unary_op[OP.SLICE, t1_shape, attrs_2](t1, expected_and_grad.expected)
-    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_2, attrs_2](t1, ug, expected_and_grad.grad_1)
+    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_2, attrs_2](
+        t1, ug, expected_and_grad.grad_1
+    )
 
     # Multiple dims
-    
+
     # dim = 0, 1
     alias slice_0_1 = Slice(23, 340, 3)
     alias slice_1_1 = Slice(10, 250, 5)
@@ -395,17 +455,32 @@ fn test_SLICE() raises:
         Attribute("starts", TensorShape(slice_0_1.start, slice_1_1.start)),
         Attribute("ends", TensorShape(slice_0_1.end, slice_1_1.end)),
         Attribute("steps", TensorShape(slice_0_1.step, slice_1_1.step)),
-        Attribute("axes", TensorShape(0, 1))
+        Attribute("axes", TensorShape(0, 1)),
     )
 
     alias ug_shape_0_1 = TensorShape(106, 48, 317)
     ug = Tensor[dtype](ug_shape_0_1)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_0_1 = PythonObject((slice_0_1.start, slice_0_1.end, slice_0_1.step, 0, slice_1_1.start, slice_1_1.end, slice_1_1.step, 1))
-    expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0_1)
+    var attrs_tuple_0_1 = PythonObject(
+        (
+            slice_0_1.start,
+            slice_0_1.end,
+            slice_0_1.step,
+            0,
+            slice_1_1.start,
+            slice_1_1.end,
+            slice_1_1.step,
+            1,
+        )
+    )
+    expected_and_grad = torch_unary_op(
+        OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0_1
+    )
     test_unary_op[OP.SLICE, t1_shape, attrs_0_1](t1, expected_and_grad.expected)
-    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_1, attrs_0_1](t1, ug, expected_and_grad.grad_1)
+    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_1, attrs_0_1](
+        t1, ug, expected_and_grad.grad_1
+    )
 
     # dim = 0, 1, 2
     alias slice_0_2 = Slice(-412, -5, 3)
@@ -413,20 +488,46 @@ fn test_SLICE() raises:
     alias slice_2_2 = Slice(293, 33, -7)
 
     alias attrs_0_2 = AttributeVector(
-        Attribute("starts", TensorShape(slice_0_2.start, slice_1_2.start, slice_2_2.start)),
-        Attribute("ends", TensorShape(slice_0_2.end, slice_1_2.end, slice_2_2.end)),
-        Attribute("steps", TensorShape(slice_0_2.step, slice_1_2.step, slice_2_2.step)),
-        Attribute("axes", TensorShape(0, 1, 2))
+        Attribute(
+            "starts",
+            TensorShape(slice_0_2.start, slice_1_2.start, slice_2_2.start),
+        ),
+        Attribute(
+            "ends", TensorShape(slice_0_2.end, slice_1_2.end, slice_2_2.end)
+        ),
+        Attribute(
+            "steps", TensorShape(slice_0_2.step, slice_1_2.step, slice_2_2.step)
+        ),
+        Attribute("axes", TensorShape(0, 1, 2)),
     )
 
     alias ug_shape_0_2 = TensorShape(136, 35, 38)
     ug = Tensor[dtype](ug_shape_0_2)
     rand(ug.data(), ug.num_elements())
 
-    var attrs_tuple_0_2 = PythonObject((slice_0_2.start, slice_0_2.end, slice_0_2.step, 0, slice_1_2.start, slice_1_2.end, slice_1_2.step, 1, slice_2_2.start, slice_2_2.end, slice_2_2.step, 2))
-    expected_and_grad = torch_unary_op(OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0_2)
+    var attrs_tuple_0_2 = PythonObject(
+        (
+            slice_0_2.start,
+            slice_0_2.end,
+            slice_0_2.step,
+            0,
+            slice_1_2.start,
+            slice_1_2.end,
+            slice_1_2.step,
+            1,
+            slice_2_2.start,
+            slice_2_2.end,
+            slice_2_2.step,
+            2,
+        )
+    )
+    expected_and_grad = torch_unary_op(
+        OP.SLICE, t1, ug, attrs_tuple=attrs_tuple_0_2
+    )
     test_unary_op[OP.SLICE, t1_shape, attrs_0_2](t1, expected_and_grad.expected)
-    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_2, attrs_0_2](t1, ug, expected_and_grad.grad_1)
+    test_unary_op_backward[OP.SLICE, t1_shape, ug_shape_0_2, attrs_0_2](
+        t1, ug, expected_and_grad.grad_1
+    )
 
 
 fn main():

--- a/tests/python/test_mlops_torch.mojo
+++ b/tests/python/test_mlops_torch.mojo
@@ -54,6 +54,12 @@ fn torch_unary_op(
             )
         elif op == OP.TANH:
             expected = torch.tanh(input_1)
+        elif op == OP.HARDTANH:
+            expected = torch.nn.functional.hardtanh(
+                input_1,
+                min_val=attrs.value()["min_val"].value().to_scalar[dtype](),
+                max_val=attrs.value()["max_val"].value().to_scalar[dtype](),
+            )
         elif op == OP.CLIP:
             var min_attr = attrs.value()["min"]
             var max_attr = attrs.value()["max"]
@@ -207,6 +213,29 @@ fn test_TANH() raises:
     test_unary_op_backward[OP.TANH, t1_shape, ug_shape](
         t1, ug, expected_and_grad.grad_1
     )
+
+
+fn test_HARDTANH() raises:
+    alias t1_shape = TensorShape(37, 63, 107)
+    alias ug_shape = TensorShape(37, 63, 107)
+    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
+    rand(t1.data(), t1.num_elements())
+
+    var ug = Tensor[dtype](ug_shape)
+    rand(ug.data(), ug.num_elements())
+
+    var expected_and_grad = torch_unary_op(OP.HARDTANH, t1, ug)
+    test_unary_op[
+        OP.HARDTANH,
+        t1_shape,
+        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
+    ](t1, expected_and_grad.expected)
+    test_unary_op_backward[
+        OP.HARDTANH,
+        t1_shape,
+        ug_shape,
+        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
+    ](t1, ug, expected_and_grad.grad_1)
 
 
 fn test_CLIP() raises:

--- a/tests/python/test_mlops_torch.mojo
+++ b/tests/python/test_mlops_torch.mojo
@@ -43,7 +43,7 @@ fn torch_unary_op(
 
         var expected: PythonObject
 
-        if op == OP.SIGMOID:
+        elif op == OP.SIGMOID:
             expected = torch.sigmoid(input_1)
         elif op == OP.RELU:
             expected = torch.relu(input_1)
@@ -54,12 +54,6 @@ fn torch_unary_op(
             )
         elif op == OP.TANH:
             expected = torch.tanh(input_1)
-        elif op == OP.HARDTANH:
-            expected = torch.nn.functional.hardtanh(
-                input_1,
-                min_val=attrs.value()["min_val"].value().to_scalar[dtype](),
-                max_val=attrs.value()["max_val"].value().to_scalar[dtype](),
-            )
         elif op == OP.CLIP:
             var min_attr = attrs.value()["min"]
             var max_attr = attrs.value()["max"]
@@ -213,29 +207,6 @@ fn test_TANH() raises:
     test_unary_op_backward[OP.TANH, t1_shape, ug_shape](
         t1, ug, expected_and_grad.grad_1
     )
-
-
-fn test_HARDTANH() raises:
-    alias t1_shape = TensorShape(37, 63, 107)
-    alias ug_shape = TensorShape(37, 63, 107)
-    var t1: Tensor[dtype] = Tensor[dtype](t1_shape)
-    rand(t1.data(), t1.num_elements())
-
-    var ug = Tensor[dtype](ug_shape)
-    rand(ug.data(), ug.num_elements())
-
-    var expected_and_grad = torch_unary_op(OP.HARDTANH, t1, ug)
-    test_unary_op[
-        OP.HARDTANH,
-        t1_shape,
-        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
-    ](t1, expected_and_grad.expected)
-    test_unary_op_backward[
-        OP.HARDTANH,
-        t1_shape,
-        ug_shape,
-        AttributeVector(Attribute("min_val", -3), Attribute("max_val", 3)),
-    ](t1, ug, expected_and_grad.grad_1)
 
 
 fn test_CLIP() raises:


### PR DESCRIPTION
The README mentioned that more activation functions are on the road map. I have gotten started. As of publishing, I only added Threshold, but I plan to go down the list from the (PyTorch Docs)[https://pytorch.org/docs/stable/nn.functional.html#non-linear-activation-functions]. Since I'm just going down the list, I'll do HardTanh next, unless someone has one they want written first. I am willing to write documentation if that is needed. Otherwise, I am trying to keep everything as close to the PyTorch docs as possible. If anybody thinks I should follow Tensoflow, Jax, or something else's docs instead, I am totally up for it as well. Here's the current TODO list for what I plan to implement first:

- [ ] threshold
- [ ] hardtanh
- [ ] hardswish
- [ ] selu
- [ ] celu
- [x] leaky_relu
- [ ] gelu
- [ ] softsign
- [ ] softplus
- [ ] softmin
- [ ] hardsigmoid
- [ ] mish
- [ ] normalize

Once I get all of those done, I'll do the rest of the ones listed on the PyTorch docs, assuming my schedule allows for it. I am more than happy to switch out anything on the list.

Also, I've noticed that the current AttributeVector system lead to a lot of type conversions, which I feel could hinder performance. I don't totally plan to look into it right now, although I could if it were necessary. 

There also seem to be a lot of overloads in the test file. Once I implement a few more activation functions, I'd like to see if I can split it into just a few basic categories that can be widely used across all the different activation functions.