### PR TITLE
Add Collection.reserve() to avoid uneeded resizing

### DIFF
--- a/basalt/nn/model.mojo
+++ b/basalt/nn/model.mojo
@@ -65,6 +65,7 @@ struct Model[
         else:
             self.perf_metrics = PerfMetrics()
 
+        # NOTE: These could be further optimized by combining into one method to save called to len()
         self.reserve_memory()
         self.allocate_tensor_memory()
         self.allocate_grad_memory()

--- a/basalt/nn/model.mojo
+++ b/basalt/nn/model.mojo
@@ -65,6 +65,7 @@ struct Model[
         else:
             self.perf_metrics = PerfMetrics()
 
+        self.reserve_memory()
         self.allocate_tensor_memory()
         self.allocate_grad_memory()
 
@@ -303,6 +304,19 @@ struct Model[
                 self.perf_metrics.end_backward_pass(i)
 
         unroll[bw_unroll, g.nodes.size]()
+
+    fn reserve_memory(inout self):
+        var input_len = len(g.inputs)
+        var param_len = len(g.params)
+        var output_nodes = len(g.nodes)
+        var output_len = 0
+
+        for i in range(len(g.nodes)):
+            output_len += len(g.nodes[i].outputs)
+
+        var size = input_len + param_len + output_len
+        self.parameters.tensors.reserve(size)
+        self.parameters.grads.reserve(size)
 
     fn allocate_tensor_memory(inout self):
         for i in range(len(g.inputs)):

--- a/basalt/utils/collection.mojo
+++ b/basalt/utils/collection.mojo
@@ -50,12 +50,10 @@ struct Collection:
         return self.size
 
     @always_inline("nodebug")
-    fn reserve(inout self, size: Int):
-        self._realloc(size)
-
-    @always_inline("nodebug")
-    fn reserve_additional(inout self, size: Int):
-        self._realloc(self.size + size)
+    fn reserve(inout self, capacity: Int):
+        self.data = UnsafePointer[Tensor[dtype]].alloc(capacity)
+        self.symbols = DTypePointer[DType.uint32].alloc(capacity)
+        self.capacity = capacity
 
     @always_inline("nodebug")
     fn _realloc(inout self, new_capacity: Int):

--- a/basalt/utils/collection.mojo
+++ b/basalt/utils/collection.mojo
@@ -1,14 +1,10 @@
 from math import max
-from memory.unsafe_pointer import UnsafePointer, move_from_pointee, initialize_pointee_copy, initialize_pointee_move, destroy_pointee
 
-from basalt import Tensor, TensorShape, Symbol
+from basalt.nn import Tensor, TensorShape
+from basalt.autograd import Symbol
 
 
-struct Collection(CollectionElement, Sized):
-    """
-    A collection of tensors with associated symbols.
-    """
-
+struct Collection:
     var size: Int
     var capacity: Int
     var data: UnsafePointer[Tensor[dtype]]
@@ -16,9 +12,6 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn __init__(inout self, *, capacity: Int = 0):
-        """
-        Initializes a new Collection with the given capacity.
-        """
         self.size = 0
         self.capacity = capacity
         self.data = UnsafePointer[Tensor[dtype]].alloc(capacity)
@@ -26,9 +19,6 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn __moveinit__(inout self, owned existing: Self):
-        """
-        Move initializes a Collection from an existing one.
-        """
         self.size = existing.size
         self.capacity = existing.capacity
         self.data = existing.data
@@ -36,48 +26,46 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn __copyinit__(inout self, existing: Self):
-        """
-        Copy initializes a Collection from an existing one.
-        """
         self.capacity = existing.capacity
         self.size = existing.size
         self.data = UnsafePointer[Tensor[dtype]].alloc(existing.capacity)
         self.symbols = DTypePointer[DType.uint32].alloc(existing.capacity)
-        memcpy(self.symbols, existing.symbols, existing.capacity)
 
         for i in range(existing.size):
             initialize_pointee_move((self.data + i), (existing.data + i)[])
 
+        memcpy(self.symbols, existing.symbols, existing.capacity)
+
     @always_inline("nodebug")
     fn __del__(owned self):
-        """
-        Destructor for the Collection.
-        """
-        for i in range(self.size):
-            destroy_pointee((self.data + i))
         if self.data:
+            for i in range(self.size):
+                destroy_pointee((self.data + i))
             self.data.free()
         if self.symbols:
             self.symbols.free()
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:
-        """
-        Returns the number of elements in the Collection.
-        """
         return self.size
 
     @always_inline("nodebug")
+    fn reserve(inout self, size: Int):
+        self._realloc(size)
+
+    @always_inline("nodebug")
+    fn reserve_additional(inout self, size: Int):
+        self._realloc(self.size + size)
+
+    @always_inline("nodebug")
     fn _realloc(inout self, new_capacity: Int):
-        """
-        Reallocates the Collection to the new capacity.
-        """
         var new_data = UnsafePointer[Tensor[dtype]].alloc(new_capacity)
         var new_symbols = DTypePointer[DType.uint32].alloc(new_capacity)
 
         for i in range(self.size):
             initialize_pointee_move((new_data + i), (self.data + i)[])
-            new_symbols[i] = self.symbols[i]
+
+        memcpy(new_symbols, self.symbols, self.capacity)
 
         self.data.free()
         self.symbols.free()
@@ -88,16 +76,10 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn append(inout self, owned value: Tensor[dtype], symbol: Symbol):
-        """
-        Appends a tensor and its associated symbol to the Collection.
-        """
         self.append(value ^, symbol.name)
 
     @always_inline("nodebug")
     fn append(inout self, owned value: Tensor[dtype], symbol_name: UInt32):
-        """
-        Appends a tensor and its associated symbol name to the Collection.
-        """
         if self.size >= self.capacity:
             self._realloc(max(1, self.capacity * 2))
         initialize_pointee_move((self.data + self.size), value ^)
@@ -106,9 +88,6 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn get_index(self, symbol_name: UInt32) -> Int:
-        """
-        Returns the index of the tensor with the given symbol name.
-        """
         for i in range(self.size):
             if self.symbols[i] == symbol_name:
                 return i
@@ -122,18 +101,12 @@ struct Collection(CollectionElement, Sized):
         self: Reference[Self, mutability, lifetime]._mlir_type,
         symbol: Symbol,
     ) -> Reference[Tensor[dtype], mutability, lifetime]:
-        """
-        Returns a reference to the tensor with the given symbol.
-        """
         var index = Reference(self)[].get_index(symbol.name)
 
         return (Reference(self)[].data + index)[]
 
     @always_inline("nodebug")
     fn clear(inout self):
-        """
-        Clears the Collection, removing all tensors and symbols.
-        """
         for i in range(self.size):
             destroy_pointee((self.data + i))
         memset_zero(self.symbols, self.capacity)
@@ -141,8 +114,5 @@ struct Collection(CollectionElement, Sized):
 
     @always_inline("nodebug")
     fn set_zero(self):
-        """
-        Zeroes out all the tensors in the collection.
-        """
         for i in range(self.size):
             self.data[i].zero()


### PR DESCRIPTION
This PR fixes a number of issues with Collection and additionally adds .reserve() and .reserve_additional() to allow Model to reserve and allocate memory at creation, rather than resizing when needed as append gets called. 

Some additional notes on collection:
- Ideally this could be simplified to just be Dict, but in Dicts current form, this is **ridiculously** slow.
- Keeping the list sorted by key and using binary search for faster access takes about the same time due to generally small list size
- DType.uint32 might be larger than needed for the use case in Basalt, and realistically could be a user specified value, or long term, a value that we can autotune for.