### PR TITLE
Changes to Onnx loader

### DIFF
--- a/basalt/autograd/attributes.mojo
+++ b/basalt/autograd/attributes.mojo
@@ -115,7 +115,7 @@ struct Attribute(Stringable, CollectionElement):
         self.size = N
 
         for i in range(self.size):
-            self.data[i] = value[i]
+            self.data_shape[i] = value[i]
 
     @always_inline("nodebug")
     fn __init__[dtype: DType](inout self, name: String, value: Scalar[dtype]):
@@ -156,7 +156,7 @@ struct Attribute(Stringable, CollectionElement):
         var result = StaticIntTuple[N]()
 
         for i in range(N):
-            result[i] = int(self.data[i])
+            result[i] = int(self.data_shape[i])
 
         return result
 

--- a/basalt/utils/tensor_creation_utils.mojo
+++ b/basalt/utils/tensor_creation_utils.mojo
@@ -1,0 +1,73 @@
+from python import Python
+
+# maybe this functions should be from the Tensor struct (like tensor.to_numpy()) and tensor.__init__(np_array: PythonObject) to create a tensor from a numpy array and tensor.copy_np_data(np_array: PythonObject) to copy the numpy array to the tensor.
+
+
+fn to_numpy(tensor: Tensor) -> PythonObject:
+    try:
+        var np = Python.import_module("numpy")
+
+        np.set_printoptions(4)
+
+        var rank = tensor.rank()
+        var dims = PythonObject([])
+        for i in range(rank):
+            dims.append(tensor.dim(i))
+        var pyarray: PythonObject = np.empty(dims, dtype=np.float32)
+
+        var pointer = int(pyarray.__array_interface__["data"][0].to_float64())
+        var pointer_d = DTypePointer[tensor.dtype](address=pointer)
+        memcpy(pointer_d, tensor.data(), tensor.num_elements())
+
+        _ = tensor
+
+        return pyarray^
+    except e:
+        print("Error in to numpy", e)
+        return PythonObject()
+
+
+fn to_tensor(np_array: PythonObject) raises -> Tensor[dtype]:
+    var shape = List[Int]()
+    for i in range(np_array.ndim):
+        shape.append(int(np_array.shape[i].to_float64()))
+    if np_array.ndim == 0:
+        # When the numpy array is a scalar, you need or the reshape to a size 1 ndarray or do this, if not the memcpy gets a memory error (Maybe because it is a register value?).
+        var tensor = Tensor[dtype](TensorShape(1))
+        tensor[0] = np_array.to_float64().cast[dtype]()
+        return tensor^
+
+    var tensor = Tensor[dtype](TensorShape(shape))
+
+    var np_array_2 = np_array.copy()
+    try:
+        var np = Python.import_module("numpy")
+        np_array_2 = np.float32(np_array_2)
+    except e:
+        print("Error in to tensor", e)
+
+    var pointer = int(np_array_2.__array_interface__["data"][0].to_float64())
+    var pointer_d = DTypePointer[tensor.dtype](address=pointer)
+    memcpy(tensor.data(), pointer_d, tensor.num_elements())
+
+    _ = np_array_2
+    _ = np_array
+
+    return tensor^
+
+
+fn copy_np_data(tensor: Tensor, np_array: PythonObject) raises:
+    var np_array_2 = np_array.copy()
+    try:
+        var np = Python.import_module("numpy")
+        np_array_2 = np.float32(np_array_2)
+    except e:
+        print("Error in to tensor", e)
+
+    var pointer = int(np_array_2.__array_interface__["data"][0].to_float64())
+    var pointer_d = DTypePointer[tensor.dtype](address=pointer)
+    memcpy(tensor.data(), pointer_d, tensor.num_elements())
+
+    _ = np_array_2
+    _ = np_array
+    _ = tensor


### PR DESCRIPTION
**Fix onnx importing (problem not considering onnx considers in many operators attributes as inputs tensors)**

Some attributes in some operators of Onnx are considered as inputs instead of attributes. What majority do is create the attributes as "constant" (special type onnx node) type nodes, so in this pull request I changed the creation from initializers to constants. And because of this it seems we don't need to care about values being initializers instead for this special cases, e.g the yolov8 Onnx model uses constants, the only initializers are the weights and biases for the convolutions.

**Extra**: Also fixed an error where static tuple was using data instead of data shape, changed this so both tensorshape and staticInttuple can be interpreted as the same type (at the end of the day they are just lists values).

**Extra not important**: Also nightly is adding the parameter decorator for for loop and it seems it doesn't unroll the loop, so now we are able to change in the forward and backward function from models from unrolled to this parameter for loop (Because we don't want to unroll this loop, A graph can get very big and an unroll here doesn't really help really, it just makes compile times slower, or at least thats what I think) [parameter for loop](https://github.com/modularml/mojo/blob/nightly/docs/changelog.md#%EF%B8%8F-new)

_And also a recursive function that uses a parameter to determine when to end gets unrolled_, because of this it isn't a recursive function anymore so you can even make the function always_inline (I have tested this), so you can create nested for loops dynamically (And the speeds are exactly the same as a nested for loop, or when you just one for loop it is also the same speed, and it is faster than a recursive function that doesn't use a parameter value.)