### PR TITLE
Making Upsample native ops

### DIFF
--- a/basalt/autograd/attributes.mojo
+++ b/basalt/autograd/attributes.mojo
@@ -68,6 +68,11 @@ struct AttributeVector(Sized, Stringable, CollectionElement):
         return None
 
     @always_inline("nodebug")
+    fn append(inout self, attribute: Attribute):
+        self.attributes[self.size] = attribute
+        self.size += 1
+
+    @always_inline("nodebug")
     fn __str__(self) -> String:
         var s: String = "["
         for i in range(self.size):

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -567,4 +567,17 @@ struct INDEX:
         t1_shape: TensorShape,
         attributes: AttributeVector = AttributeVector(),
     ](ug: Tensor[dtype], t1: Tensor[dtype]) -> Tensor[dtype]:
-        return Tensor[dtype]()
+        alias indeces = Self.to_indeces(t1_shape, attributes)
+        alias strides = t1_shape.strides()
+
+        var res_grad = Tensor[dtype](t1_shape)
+
+        var j = 0
+        for comb in product(indeces):
+            var flat_index = 0
+            for dim in range(t1_shape.rank()):
+                flat_index += comb[dim] * strides[dim]
+            res_grad[flat_index] += ug[j]
+            j += 1
+        
+        return res_grad^

--- a/basalt/autograd/ops/mlops.mojo
+++ b/basalt/autograd/ops/mlops.mojo
@@ -546,20 +546,43 @@ struct INDEX:
         return TensorShape(new_shape)
 
     @staticmethod
+    fn map_indeces[
+        nelts: Int,
+        strides: TensorShape,
+        indeces: List[List[Int]],
+    ](idx: Int) -> SIMD[DType.int64, nelts]:
+        alias indeces_product = product(indeces)
+
+        var temp = SIMD[DType.int64, nelts]()
+        for i in range(idx, idx + nelts):
+            var comb = indeces_product[i]
+            var flat_index = 0
+
+            for dim in range(len(comb)):
+                flat_index += comb[dim] * strides[dim]
+
+            temp[i % nelts] = flat_index
+
+        return temp
+
+    @staticmethod
     fn forward[
         t1_shape: TensorShape,
         attributes: AttributeVector,
     ](inout res: Tensor[dtype], t1: Tensor[dtype]):
         alias indeces = Self.to_indeces(t1_shape, attributes)
         alias strides = t1_shape.strides()
+        alias total_length = len(product(indeces))
 
-        var j = 0
-        for comb in product(indeces):
-            var flat_index = 0
-            for dim in range(t1_shape.rank()):
-                flat_index += comb[dim] * strides[dim]
-            res[j] = t1[flat_index]
-            j += 1
+        @parameter
+        fn vec_index[nelts: Int](i: Int):
+
+            res.store[nelts](i,
+                t1.data().gather(Self.map_indeces[nelts, strides, indeces](i))
+            )
+
+        vectorize[vec_index, nelts](total_length)
+
 
     @staticmethod
     fn backward[
@@ -569,8 +592,24 @@ struct INDEX:
     ](ug: Tensor[dtype], t1: Tensor[dtype]) -> Tensor[dtype]:
         alias indeces = Self.to_indeces(t1_shape, attributes)
         alias strides = t1_shape.strides()
+        # alias total_length = len(product(indeces))
 
         var res_grad = Tensor[dtype](t1_shape)
+
+        # @parameter
+        # fn vec_index[nelts: Int](i: Int):
+
+        #     var offset = Self.map_indeces[nelts, strides, indeces](i)
+        #     res_grad.data().scatter(
+        #         offset,
+        #         res_grad.data().gather(offset) + ug.load[nelts](i),
+        #     )
+        
+        # vectorize[vec_index, nelts](total_length)
+        
+        # BUG: Edge case in vectorization:
+        # When the offset = [0, 2, 4, 0] and ug = [1, 1, 1, 1]
+        # It doesn't scatter to index 0 twice as it should be: res_grad[0] += 1 + 1
 
         var j = 0
         for comb in product(indeces):
@@ -579,5 +618,5 @@ struct INDEX:
                 flat_index += comb[dim] * strides[dim]
             res_grad[flat_index] += ug[j]
             j += 1
-        
+
         return res_grad^

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,7 +15,7 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE
+from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE, INDEX
 from .dynamics import CONCAT, SPLIT
 from .conv import CONV2D
 from .pool import MAXPOOL2D
@@ -61,6 +61,7 @@ struct OP(Stringable):
     alias CONCAT = OP(23, "CONCAT", dynamic=True)
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
+    alias INDEX = OP(26, "INDEX")
 
     var id: UInt8
     var name: Bytes[16]
@@ -135,6 +136,8 @@ fn static_result_shape(
         return UNSQUEEZE.result_shape(t1_shape, attributes)
     elif op == OP.SLICE:
         return SLICE.result_shape(t1_shape, attributes)
+    elif op == OP.INDEX:
+        return INDEX.result_shape(t1_shape, attributes)
     else:
         print("[ERROR] Operator not found.")
         return TensorShape(-1)
@@ -249,6 +252,8 @@ fn forward_op[
         UNSQUEEZE.forward[t1_shape, attributes](res, t1)
     elif op == OP.SLICE:
         SLICE.forward[t1_shape, attributes](res, t1)
+    elif op == OP.INDEX:
+        INDEX.forward[t1_shape, attributes](res, t1)
     else:
         print("[ERROR] Operator not found.")
 
@@ -361,6 +366,8 @@ fn backward_op[
         res_grad = UNSQUEEZE.backward[ug_shape, t1_shape](ug, t1)
     elif op == OP.SLICE:
         res_grad = SLICE.backward[ug_shape, t1_shape, attributes](ug, t1)
+    elif op == OP.INDEX:
+        res_grad = INDEX.backward[ug_shape, t1_shape, attributes](ug, t1)
     else:
         print("[ERROR] Operator not found.")
         res_grad = Tensor[dtype](-1)

--- a/basalt/autograd/ops/ops.mojo
+++ b/basalt/autograd/ops/ops.mojo
@@ -15,7 +15,7 @@ from .basics import (
     TRANSPOSE,
     FMA,
 )
-from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE, INDEX
+from .mlops import SIGMOID, RELU, TANH, CLIP, SQUEEZE, UNSQUEEZE, SLICE, INDEX, UPSAMPLE
 from .dynamics import CONCAT, SPLIT
 from .conv import CONV2D
 from .pool import MAXPOOL2D
@@ -62,6 +62,7 @@ struct OP(Stringable):
     alias SPLIT = OP(24, "SPLIT", dynamic=True)
     alias SLICE = OP(25, "SLICE")
     alias INDEX = OP(26, "INDEX")
+    alias UPSAMPLE = OP(27, "UPSAMPLE")
 
     var id: UInt8
     var name: Bytes[16]
@@ -138,6 +139,8 @@ fn static_result_shape(
         return SLICE.result_shape(t1_shape, attributes)
     elif op == OP.INDEX:
         return INDEX.result_shape(t1_shape, attributes)
+    elif op == OP.UPSAMPLE:
+        return UPSAMPLE.result_shape(t1_shape, attributes)
     else:
         print("[ERROR] Operator not found.")
         return TensorShape(-1)
@@ -254,6 +257,8 @@ fn forward_op[
         SLICE.forward[t1_shape, attributes](res, t1)
     elif op == OP.INDEX:
         INDEX.forward[t1_shape, attributes](res, t1)
+    elif op == OP.UPSAMPLE:
+        UPSAMPLE.forward[t1_shape, attributes](res, t1)
     else:
         print("[ERROR] Operator not found.")
 

--- a/basalt/nn/__init__.mojo
+++ b/basalt/nn/__init__.mojo
@@ -4,6 +4,7 @@ from .model import Model
 from .layers.linear import Linear
 from .layers.conv import Conv2d
 from .layers.pool import MaxPool2d
+from .layers.upsample import Upsample
 
 from .loss import MSELoss, CrossEntropyLoss
 from .activations import Softmax, LogSoftmax, ReLU, Sigmoid, Tanh

--- a/basalt/nn/layers/upsample.mojo
+++ b/basalt/nn/layers/upsample.mojo
@@ -1,0 +1,117 @@
+from basalt import dtype
+from basalt import Graph, Symbol, OP
+from basalt import Tensor, TensorShape
+from basalt.autograd.attributes import AttributeVector, Attribute
+from basalt.utils.itertools import product
+
+
+fn _scale_indeces(N: Int, scale: Scalar[dtype], align_corners: Bool, dim: Int, ndims: Int) -> List[Scalar[dtype]]:    
+    var M = int(scale * N)
+    var indeces = List[Scalar[dtype]]()
+    if align_corners:
+        for i in range(M):
+            indeces.append(i * ((N - 1) / (M - 1)))
+    else:
+        var step = 1 / scale
+        var start = ((M - 1) * step - N + 1) / 2
+        for i in range(M):
+            indeces.append(i * step - start)
+
+    return indeces ^
+
+
+fn nearest_coeffs(N: Int, scale: Scalar[dtype], dim: Int, ndims: Int) -> List[Int]:
+    
+    @parameter
+    fn round_to_index(number: Scalar[dtype]) -> Int:
+        return int(number + 0.5) if number > 0 else int(number - 0.5)
+    
+    var indeces = List[Int]()
+    var scaled = _scale_indeces(N, scale, True, dim, ndims)
+    for i in range(len(scaled)):
+        indeces.append(round_to_index(scaled[i]))
+    return indeces ^
+
+
+fn linear_coeffs(N: Int, scale: Scalar[dtype], align_corners: Bool, dim: Int, ndims: Int) -> Tuple[List[Int], List[Int]]:
+    # TODO
+    return (List[Int](), List[Int]())
+
+
+fn cubic_coeffs(N: Int, scale: Scalar[dtype], align_corners: Bool, dim: Int, ndims: Int) -> Tuple[List[Int], List[Int]]:
+    # TODO
+    return (List[Int](), List[Int]())
+
+
+fn interpolate_nd[
+    indices_fn: fn (Int, Scalar[dtype], Bool, Int, Int) -> Tuple[List[Int], List[Int]],
+](inout g: Graph, input: Symbol, scale_factors: List[Scalar[dtype]], align_corners: Bool) -> Symbol:
+
+    var spatial_dims = input.shape.rank() - 2
+    
+    var indeces_weights = List[Tuple[List[Int], List[Int]]]()
+    for i in range(spatial_dims):
+        indeces_weights.append(
+            indices_fn(
+                input.shape[i + 2],
+                scale_factors[i],
+                align_corners,
+                i,
+                spatial_dims,
+            )
+        )
+
+    # TODO: interpolation logic
+    # for idx_weight in product(indeces_weights):
+    #     ...
+
+    return Symbol(-1, dtype, TensorShape(), False)
+
+
+fn Upsample(
+    inout g: Graph,
+    input: Symbol,
+    mode: StringLiteral,
+    scale_factors: List[Scalar[dtype]],
+    align_corners: Bool = False,
+) -> Symbol:
+
+    # Assumption: A scale needs to be provided for each spatial dimension.
+    # input shape (B, C, *N) with batch and channel considered as non-spatial dimensions.
+    # input.shape.rank() - 2 == len(scale_factor)
+    var spatial_dims = input.shape.rank() - 2
+
+    var res: Symbol
+    var attributes = AttributeVector()
+    var INDEX_LITERALS = List[StringLiteral]("dim_2i", "dim_3i", "dim_4i")
+
+    if mode == "nearest":
+        # Nearest neighbor interpolation --> input[:, :, *indeces]
+        for i in range(spatial_dims):            
+            attributes.append(
+                Attribute(
+                    INDEX_LITERALS[i],
+                    nearest_coeffs(input.shape[i + 2], scale_factors[i], i, spatial_dims)
+                )
+            )
+
+        res = g.op(OP.INDEX, input, attributes=attributes)
+
+    # elif mode == "linear":
+    #     res = interpolate_nd[linear_coeffs](g, 
+    #         input,
+    #         scale_factor,
+    #         align_corners
+    #     )
+    
+    # elif mode == "cubic":
+    #     res = interpolate_nd[cubic_coeffs](g, 
+    #         input,
+    #         scale_factor,
+    #         align_corners
+    #     )
+    else:
+        res = input
+
+    return res
+

--- a/basalt/utils/itertools.mojo
+++ b/basalt/utils/itertools.mojo
@@ -1,0 +1,47 @@
+
+@value
+struct _ProductIterator(Sized):
+    var lists: List[List[Int]]
+    var indeces: List[Int]
+    var _iters: Int
+
+    @always_inline("nodebug")
+    fn __init__(inout self, lists: List[List[Int]]):
+        self.lists = lists
+        self.indeces = List[Int]()
+        for i in range(len(lists)):
+            self.indeces.append(0)
+        
+        self._iters = 1
+        for lst in self.lists:
+            self._iters *= len(lst[])
+
+    @always_inline("nodebug")
+    fn __len__(self) -> Int:
+        return self._iters
+
+    @always_inline("nodebug")
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline("nodebug")
+    fn __next__(inout self) -> List[Int]:
+        var res = List[Int]()
+        for i in range(len(self.lists)):
+            res.append(self.lists[i][self.indeces[i]])
+        self._increment_indeces()
+        self._iters -= 1
+        return res ^
+
+    @always_inline("nodebug")
+    fn _increment_indeces(inout self):
+        for i in reversed(range(len(self.indeces))):
+            self.indeces[i] += 1
+            if self.indeces[i] < len(self.lists[i]):
+                break
+            self.indeces[i] = 0
+
+
+@always_inline("nodebug")
+fn product(lists: List[List[Int]]) -> _ProductIterator:
+    return _ProductIterator(lists)

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -649,6 +649,36 @@ fn test_INDEX() raises:
     print(expected)
 
 
+fn test_INDEX_backward() raises:
+    alias t1_shape = TensorShape(2, 3, 5)
+    var t = Tensor[dtype](t1_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    alias attr_1 = Attribute("dim_1i", TensorShape(0, 0))
+    alias attr_2 = Attribute("dim_2s", TensorShape(0, 5, 2))
+
+    alias ug_shape = TensorShape(2, 2, 3)
+    var ug = Tensor[dtype](ug_shape)
+    fill(ug, 1.0)
+
+    var expected = Tensor[dtype](t1_shape)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                # NOTE: `+=` because selected indeces [0, 0] can repeat
+                expected[i * 3 * 5 + k * 2] += 1.0 
+
+    test_unary_op_backward[
+        OP.INDEX, t1_shape, ug_shape, AttributeVector(
+            attr_1,
+            attr_2,
+        )
+    ](t, ug, expected)
+
+    print(expected)
+
+
 fn main():
     try:
         # test_SIGMOID()
@@ -667,16 +697,17 @@ fn main():
         print(e)
         return
 
-    # try:
-    #     test_backward_SIGMOID()
-    #     test_backward_RELU()
-    #     test_backward_TANH()
-    #     test_backward_CLIP()
-    #     test_backward_SQUEEZE()
-    #     test_backward_UNSQUEEZE()
-    #     test_backward_SLICE()
-    #     test_backward_SLICE_multiple_axes()
-    # except e:
-    #     print("[ERROR] Error in backward mlops")
-    #     print(e)
-    #     return
+    try:
+        # test_backward_SIGMOID()
+        # test_backward_RELU()
+        # test_backward_TANH()
+        # test_backward_CLIP()
+        # test_backward_SQUEEZE()
+        # test_backward_UNSQUEEZE()
+        # test_backward_SLICE()
+        # test_backward_SLICE_multiple_axes()
+        test_INDEX_backward()
+    except e:
+        print("[ERROR] Error in backward mlops")
+        print(e)
+        return

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -620,33 +620,63 @@ fn test_backward_SLICE_multiple_axes() raises:
     ](t1, ug, expected_ug)
 
 
+from basalt.autograd.ops.mlops import INDEX
+
+fn test_INDEX() raises:
+    alias t1_shape = TensorShape(2, 3, 5)
+    var t = Tensor[dtype](t1_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    # t[:, [0, 0], 0:5:2]
+    # TODO: need for a list attribute as this only supports to specify indeces of MAX_RANK
+    alias attr_1 = Attribute("dim_1i", TensorShape(0, 0))
+    alias attr_2 = Attribute("dim_2s", TensorShape(0, 5, 2))
+
+    var expected = Tensor[dtype](2, 2, 3)
+    for i in range(2):
+        for j in range(2):
+            for k in range(3):
+                expected[i*2*3 + j*3 + k] = i * 3 * 5 + k * 2
+
+    test_unary_op[
+        OP.INDEX, t1_shape, AttributeVector(
+            attr_1,
+            attr_2,
+        )
+    ](t, expected)
+
+    print(expected)
+
+
 fn main():
     try:
-        test_SIGMOID()
-        test_RELU()
-        test_TANH()
-        test_CLIP()
-        test_SQUEEZE()
-        test_UNSQUEEZE()
-        test_SLICE()
-        test_SLICE_step()
-        test_SLICE_neg()
-        test_SLICE_multiple_axes()
+        # test_SIGMOID()
+        # test_RELU()
+        # test_TANH()
+        # test_CLIP()
+        # test_SQUEEZE()
+        # test_UNSQUEEZE()
+        # test_SLICE()
+        # test_SLICE_step()
+        # test_SLICE_neg()
+        # test_SLICE_multiple_axes()
+        test_INDEX()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
         return
 
-    try:
-        test_backward_SIGMOID()
-        test_backward_RELU()
-        test_backward_TANH()
-        test_backward_CLIP()
-        test_backward_SQUEEZE()
-        test_backward_UNSQUEEZE()
-        test_backward_SLICE()
-        test_backward_SLICE_multiple_axes()
-    except e:
-        print("[ERROR] Error in backward mlops")
-        print(e)
-        return
+    # try:
+    #     test_backward_SIGMOID()
+    #     test_backward_RELU()
+    #     test_backward_TANH()
+    #     test_backward_CLIP()
+    #     test_backward_SQUEEZE()
+    #     test_backward_UNSQUEEZE()
+    #     test_backward_SLICE()
+    #     test_backward_SLICE_multiple_axes()
+    # except e:
+    #     print("[ERROR] Error in backward mlops")
+    #     print(e)
+    #     return

--- a/tests/mojo/test_mlops.mojo
+++ b/tests/mojo/test_mlops.mojo
@@ -679,6 +679,48 @@ fn test_INDEX_backward() raises:
     print(expected)
 
 
+fn test_UPSAMPLE() raises:
+    alias t1_shape = TensorShape(2, 3, 5)
+    var t = Tensor[dtype](t1_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    var expected = Tensor[dtype](2, 3, 10)
+    for i in range(2):
+        for j in range(3):
+            for k in range(5):
+                for l in range(2):
+                    expected[i*3*10 + j*10 + k*2 + l] = t[i*3*5 + j*5 + k]
+
+    test_unary_op[
+        OP.UPSAMPLE, t1_shape, AttributeVector(
+            Attribute("scales", TensorShape(2)),
+            Attribute("mode", "nearest")
+        )
+    ](t, expected)
+
+
+    alias t2_shape = TensorShape(1, 1, 2, 2)
+    t = Tensor[dtype](t2_shape)
+    for i in range(t.num_elements()):
+        t[i] = i
+
+    expected = Tensor[dtype](1, 1, 4, 6)
+    for i in range(1):
+        for j in range(1):
+            for k in range(4):
+                for l in range(6):
+                    var pos = i*1*2*2 + j*2*2 + (k // 2) * 2 + (l // 3)
+                    expected[i*1*4*6 + j*4*6 + k*6 + l] = t[pos]
+    
+    test_unary_op[
+        OP.UPSAMPLE, t2_shape, AttributeVector(
+            Attribute("scales", TensorShape(2, 3)),
+            Attribute("mode", "nearest")
+        )
+    ](t, expected)
+
+
 fn main():
     try:
         # test_SIGMOID()
@@ -691,7 +733,8 @@ fn main():
         # test_SLICE_step()
         # test_SLICE_neg()
         # test_SLICE_multiple_axes()
-        test_INDEX()
+        # test_INDEX()
+        test_UPSAMPLE()
     except e:
         print("[ERROR] Error in forward mlops")
         print(e)
@@ -706,7 +749,8 @@ fn main():
         # test_backward_UNSQUEEZE()
         # test_backward_SLICE()
         # test_backward_SLICE_multiple_axes()
-        test_INDEX_backward()
+        # test_INDEX_backward()
+        pass
     except e:
         print("[ERROR] Error in backward mlops")
         print(e)

--- a/tests/python/test_upsample.mojo
+++ b/tests/python/test_upsample.mojo
@@ -1,0 +1,159 @@
+from python.python import Python, PythonObject
+
+import basalt.nn as nn
+from basalt import dtype, Graph
+from basalt import Tensor, TensorShape
+from tests import assert_tensors_equal, to_numpy, to_tensor
+
+
+fn test_upsample[
+    shape: TensorShape,
+    mode: StringLiteral,
+    scale_factors: List[Scalar[dtype]],
+    align_corners: Bool
+](
+    t1: Tensor[dtype],
+    ug: Tensor[dtype],
+    expected: Tensor[dtype],
+    expected_grad: Tensor[dtype]
+) raises:
+
+    fn create_graph() -> Graph:
+        var g = Graph()
+        var t1 = g.input(shape, trainable=True)
+        var t2 = nn.Upsample(g, t1, mode, scale_factors, align_corners)
+        g.out(t2)
+        return g ^
+
+    alias graph = create_graph()
+    var model = nn.Model[graph](inference_only=True)
+    var res = model.inference(t1)[0]
+
+    model.backward(ug)
+    var res_grad = model.parameters.grads[graph.inputs[0]]
+
+    assert_tensors_equal["almost"](res, expected)
+    assert_tensors_equal["almost"](res_grad, expected_grad)
+
+
+@value
+struct torch_upsample_result:
+    var expected: Tensor[dtype]
+    var grad: Tensor[dtype]
+
+
+fn test_upsample_torch[
+    shape: TensorShape,
+    mode: StringLiteral,
+    scale_factors: List[Scalar[dtype]],
+    align_corners: Bool
+](data: PythonObject, ug: PythonObject) raises -> torch_upsample_result:
+
+    var py = Python.import_module("builtins")
+    var np = Python.import_module("numpy")
+    var torch = Python.import_module("torch")
+
+    var py_scales = py.list()
+    for i in range(len(scale_factors)):
+        py_scales.append(scale_factors[i])
+
+    # if mode == "nearest":
+        # var ups = torch.nn.Upsample(scale_factor=py.tuple(py_scales), mode=mode)
+    # else:
+        # var ups = torch.nn.Upsample(scale_factor=py.tuple(py_scales), mode=mode, align_corners=align_corners)
+
+    var ups = torch.nn.Upsample(scale_factor=py.tuple(py_scales), mode=mode)
+
+    var tensor = torch.from_numpy(data).requires_grad_(True)
+    var expected = ups(tensor)
+    var upper_grad = torch.from_numpy(ug)
+    _ = expected.backward(upper_grad)
+
+    return torch_upsample_result(
+        to_tensor(expected.detach().numpy()),
+        to_tensor(tensor.grad.numpy()),
+    )
+
+
+
+fn test_UPSAMPLE_nearest() raises:
+    var np = Python.import_module("numpy")
+
+    alias shape = TensorShape(1, 1, 2, 2)
+    alias mode: StringLiteral = "nearest"
+    alias scales = List[Scalar[dtype]](2.0, 3.0)
+    alias align_corners = False
+
+    var data = np.array([
+        1, 2,
+        3, 4
+    ], dtype=np.float32).reshape(1, 1, 2, 2)
+
+    var ug = np.ones((1, 1, 4, 6))
+    
+    var torch_out = test_upsample_torch[shape, mode, scales, align_corners](data, ug)
+    test_upsample[shape, mode, scales, align_corners](
+        to_tensor(data),
+        to_tensor(ug),
+        torch_out.expected,
+        torch_out.grad
+    )
+
+    _ = data
+
+
+fn test_UPSAMPLE_linear() raises:
+    var np = Python.import_module("numpy")
+
+    alias shape = TensorShape(1, 1, 2, 2)
+    alias mode: StringLiteral = "linear"
+    alias scales = List[Scalar[dtype]](2.0, 2.0)
+
+    var data = np.array([
+        1, 2,
+        3, 4
+    ], dtype=np.float32).reshape(1, 1, 2, 2)
+
+    # var expected = np.array([
+    #     1.,   1.25, 1.75, 2.  ,
+    #     1.5,  1.75, 2.25, 2.5 ,
+    #     2.5,  2.75, 3.25, 3.5 ,
+    #     3.,   3.25, 3.75, 4.  ,
+    # ], dtype=np.float32).reshape(1, 1, 4, 4)
+
+
+fn test_UPSAMPLE_cubic() raises:
+    var np = Python.import_module("numpy")
+
+    alias shape = TensorShape(1, 1, 4, 4)
+    alias mode: StringLiteral = "cubic"
+    alias scales = List[Scalar[dtype]](2.0, 2.0)
+
+    var data = np.array([
+        1,  2,  3,  4,
+        5,  6,  7,  8,
+        9,  10, 11, 12,
+        13, 14, 15, 16,
+    ], dtype=np.float32).reshape(1, 1, 4, 4)
+
+    # var expected = np.array([
+    #      0.47265625,  0.76953125,  1.24609375,  1.875,       2.28125,   2.91015625,  3.38671875,  3.68359375,
+    #      1.66015625,  1.95703125,  2.43359375,  3.0625,      3.46875,   4.09765625,  4.57421875,  4.87109375,
+    #      3.56640625,  3.86328125,  4.33984375,  4.96875,     5.375,     6.00390625,  6.48046875,  6.77734375,
+    #      6.08203125,  6.37890625,  6.85546875,  7.484375,    7.890625,  8.51953125,  8.99609375,  9.29296875,
+    #      7.70703125,  8.00390625,  8.48046875,  9.109375,    9.515625, 10.14453125, 10.62109375, 10.91796875,
+    #     10.22265625, 10.51953125, 10.99609375, 11.625,      12.03125,  12.66015625, 13.13671875, 13.43359375,
+    #     12.12890625, 12.42578125, 12.90234375, 13.53125,    13.9375,   14.56640625, 15.04296875, 15.33984375,
+    #     13.31640625, 13.61328125, 14.08984375, 14.71875,    15.125,    15.75390625, 16.23046875, 16.52734375
+    # ], dtype=np.float32).reshape(1, 1, 8, 8)
+
+
+fn main():
+
+    try:
+        test_UPSAMPLE_nearest()
+        # test_UPSAMPLE_linear()
+        # test_UPSAMPLE_cubic()
+    except e:
+        print("[Error] Error in Upsample")
+        print(e)


### PR DESCRIPTION
This is a pr that is making the upsample ops native instead of using the index op and the operation for the mode.


- [x] nearest
- [ ] linear
- [ ] bilinear
- [ ] bicubic
- [ ] trilinear


P.S. If you don't want this stijn you can close this pr.